### PR TITLE
mock for tornado 'gen' generator

### DIFF
--- a/consulate/adapters.py
+++ b/consulate/adapters.py
@@ -10,8 +10,12 @@ try:
     from tornado import gen
     from tornado import httpclient
 except ImportError:
-    gen, httpclient = None, None
+    httpclient = None
 
+    class Gen:
+        def coroutine(self, func):
+            pass
+    gen = Gen()
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
I am getting this error when running `consulate` in my system, please check the patch.

```
$ consulate
Traceback (most recent call last):
  File "/usr/local/bin/consulate", line 9, in <module>
    load_entry_point('consulate==0.2.0', 'console_scripts', 'consulate')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 351, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2363, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2088, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/usr/local/lib/python2.7/dist-packages/consulate/__init__.py", line 7, in <module>
    from consulate.api import Consulate
  File "/usr/local/lib/python2.7/dist-packages/consulate/api.py", line 10, in <module>
    from consulate import adapters
  File "/usr/local/lib/python2.7/dist-packages/consulate/adapters.py", line 59, in <module>
    class TornadoRequest(Request):
  File "/usr/local/lib/python2.7/dist-packages/consulate/adapters.py", line 66, in TornadoRequest
    @gen.coroutine
AttributeError: 'NoneType' object has no attribute 'coroutine'
```
