### PR TITLE
Move #8 correction from cli to api - to fix #6 and #8 - problem is the same

### DIFF
--- a/consulate/api.py
+++ b/consulate/api.py
@@ -485,15 +485,17 @@ class KV(_Endpoint):
         item = item.lstrip('/')
         response = self._adapter.get(self._build_uri([item]))
         index = 0
+        if isinstance(value, (str, unicode)):
+            value = value.encode('utf-8')
         if response.status_code == 200:
             index = response.body.get('ModifyIndex')
-            if response.body.get('Value') == value.encode('utf-8'):
+            if response.body.get('Value') == value:
                 return True
         query_params = {'index': index}
         if flags is not None:
             query_params['flags'] = flags
         response = self._adapter.put(self._build_uri([item], query_params),
-                                     value.encode('utf-8'))
+                                     value)
         if not response.status_code == 200 or not response.body:
             raise KeyError(
                 'Error setting "{0}" ({1})'.format(item, response.status_code))

--- a/consulate/api.py
+++ b/consulate/api.py
@@ -487,13 +487,13 @@ class KV(_Endpoint):
         index = 0
         if response.status_code == 200:
             index = response.body.get('ModifyIndex')
-            if response.body.get('Value') == value:
+            if response.body.get('Value') == value.encode('utf-8'):
                 return True
         query_params = {'index': index}
         if flags is not None:
             query_params['flags'] = flags
         response = self._adapter.put(self._build_uri([item], query_params),
-                                     value)
+                                     value.encode('utf-8'))
         if not response.status_code == 200 or not response.body:
             raise KeyError(
                 'Error setting "{0}" ({1})'.format(item, response.status_code))

--- a/consulate/api.py
+++ b/consulate/api.py
@@ -485,8 +485,14 @@ class KV(_Endpoint):
         item = item.lstrip('/')
         response = self._adapter.get(self._build_uri([item]))
         index = 0
-        if isinstance(value, (str, unicode)):
-            value = value.encode('utf-8')
+
+        try:
+            if isinstance(value, (str, unicode)):
+                value = value.encode('utf-8')
+        except NameError:  #in Python3 str is unicode by default
+            if isinstance(value, str):
+                value = value.encode('utf-8')
+
         if response.status_code == 200:
             index = response.body.get('ModifyIndex')
             if response.body.get('Value') == value:

--- a/consulate/cli.py
+++ b/consulate/cli.py
@@ -98,7 +98,7 @@ def main():
             with open(args.restore_file, 'rb') as handle:
                 data = json.load(handle)
                 for row in data:
-                    session.kv.set_record(row[0], row[1], row[2].encode('utf-8'))
+                    session.kv.set_record(row[0], row[1], row[2])
 
         elif args.action == 'del':
             del session.kv[args.key]


### PR DESCRIPTION
I found out that #6 and #8 are one the same problem. So better if this gonna be fixed in one place - in api.
But for that we have to exclude 'non str' and 'non unicode' values usecases (int and bool have no attribute 'encode').