### PR TITLE
Made tornado a required package; Fixed pip requirement files

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,6 @@
-coverage
-httmock
-mock
-nose
-requests
-simplejson
-tornado
+-r requirements.txt
+coverage==3.7.1
+httmock==1.2.2
+mock==1.0.1
+nose==1.3.4
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-requests
-simplejson
+requests==2.5.3
+simplejson==3.6.5
+tornado==4.1

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 import sys
 
-install_requires = ['requests']
+install_requires = ['requests', 'tornado']
 
 if sys.version_info < (2, 7, 0):
     install_requires.append('argparse')
@@ -14,7 +14,6 @@ setup(name='consulate',
       url="https://consulate.readthedocs.org",
       install_requires=install_requires,
       license=open('LICENSE').read(),
-      extras_require={'tornado': 'tornado'},
       package_data={'': ['LICENSE', 'README.rst']},
       packages=['consulate'],
       entry_points=dict(console_scripts=['consulate=consulate.cli:main']),


### PR DESCRIPTION
### What is the problem / feature ?

Ran into the `tornado` not installed problem. Found here: https://github.com/gmr/consulate/issues/10

```
    import consulate
/Users/adamc/.envs/envconsul/lib/python2.7/site-packages/consulate/__init__.py:7: in <module>
    from consulate.api import Consulate
/Users/adamc/.envs/envconsul/lib/python2.7/site-packages/consulate/api.py:10: in <module>
    from consulate import adapters
/Users/adamc/.envs/envconsul/lib/python2.7/site-packages/consulate/adapters.py:59: in <module>
    class TornadoRequest(Request):
/Users/adamc/.envs/envconsul/lib/python2.7/site-packages/consulate/adapters.py:66: in TornadoRequest
    @gen.coroutine
E   AttributeError: 'NoneType' object has no attribute 'coroutine'
```


### How did it get fixed / implemented ?

- Locked down package versions in requirements files
- Applied pip's file ineheratence to remove duplication in pip requirements files
- Added `tornado` as a required package in `setup.py`

### How can someone test / see it ?

- Cloned/download and execute `pip install -e .` Now installs tornado
