### PR TITLE
Added no-replace flag for restore method

### DIFF
--- a/consulate/api/kv.py
+++ b/consulate/api/kv.py
@@ -265,14 +265,15 @@ class KV(base.Endpoint):
         """
         return self.__setitem__(item, value)
 
-    def set_record(self, item, flags=0, value=None):
+    def set_record(self, item, flags=0, value=None, replace=True):
         """Set a full record, including the item flag
 
         :param str item: The key to set
         :param mixed value: The value to set
+        :param replace: If True existing value will be overwritten:
 
         """
-        self._set_item(item, value, flags)
+        self._set_item(item, value, flags, replace)
 
     def values(self):
         """Return a list of all of the values in the Key/Value service
@@ -324,13 +325,14 @@ class KV(base.Endpoint):
             return response.body
         return None
 
-    def _set_item(self, item, value, flags=None):
+    def _set_item(self, item, value, flags=None, replace=True):
         """Internal method for setting a key/value pair with flags in the
         Key/Value service
 
         :param str item: The key to set
         :param mixed value: The value to set
         :param int flags: User defined flags to set
+        :param bool replace: Overwrite existing values
         :raises: KeyError
 
         """
@@ -349,6 +351,8 @@ class KV(base.Endpoint):
         if response.status_code == 200:
             index = response.body.get('ModifyIndex')
             if response.body.get('Value') == value:
+                return True
+            if not replace:
                 return True
         query_params = {'cas': index}
         if flags is not None:

--- a/consulate/cli.py
+++ b/consulate/cli.py
@@ -37,6 +37,8 @@ def add_kv_args(parser):
     restore.add_argument('-f', '--file',
                          help='JSON file to read instead of stdin',
                          nargs="?", type=open)
+    restore.add_argument('-n', '--no-replace', help='Do not replace existing entries',
+                         action='store_true')
 
     kvls = kvsparsers.add_parser('ls', help='List all of the keys')
     kvls.add_argument('-l', '--long', help='Long format', action='store_true')
@@ -200,7 +202,10 @@ def kv_restore(consul, args):
         if not utils.PYTHON3 and isinstance(row[2], unicode):
             row[2] = row[2].encode('utf-8')
         try:
-            consul.kv.set_record(row[0], row[1], row[2])
+            if args.no_replace:
+                consul.kv.set_record(row[0], row[1], row[2], False)
+            else:
+                consul.kv.set_record(row[0], row[1], row[2], True)
         except exceptions.ConnectionError:
             connection_error()
 


### PR DESCRIPTION
When restoring data now you have two choices:
restore by overwrite everything (current) 
or use the --no-replace flag to not overwrite existing values (new)