### PR TITLE
Make UNIX socket support optional

### DIFF
--- a/consulate/adapters.py
+++ b/consulate/adapters.py
@@ -6,7 +6,10 @@ import json
 import logging
 
 import requests
-import requests_unixsocket
+# Module imported lazily by UnixSocketRequest.__init__()
+# The rest of this library will work without UNIX socket support
+# even if requests_unixsocket cannot be loaded
+requests_unixsocket = None
 
 from consulate import api
 from consulate import utils
@@ -107,10 +110,13 @@ class Request(object):
         return api.Response(response.status_code, response.content,
                             response.headers)
 
-
 class UnixSocketRequest(Request):
     """Use to communicate with Consul over a Unix socket"""
 
     def __init__(self, timeout=None):
         super(UnixSocketRequest, self).__init__(timeout)
+        # Load the requests_unixsocket module on demand only.
+        global requests_unixsocket
+        if requests_unixsocket is None:
+            import requests_unixsocket
         self.session = requests_unixsocket.Session()

--- a/consulate/cli.py
+++ b/consulate/cli.py
@@ -303,9 +303,9 @@ def main():
     args = parse_cli_args()
 
     if args.api_scheme == 'http+unix':
-        adapter = None
-    else:
         adapter = adapters.UnixSocketRequest
+    else:
+        adapter = None
 
     consul = consulate.Consul(args.api_host, args.api_port, args.dc,
                               args.token, args.api_scheme, adapter)

--- a/consulate/cli.py
+++ b/consulate/cli.py
@@ -265,7 +265,7 @@ def register(consul, args):
     """
     check = args.path if args.ctype == 'check' else None
     httpcheck = args.url if args.ctype == 'httpcheck' else None
-    interval = '%ss' % args.interval if 'check' in args.ctype else None
+    interval = '%ss' % args.interval if args.ctype in ['check', 'httpcheck'] else None
     ttl = '%ss' % args.duration if args.ctype == 'ttl' else None
     tags = args.tags.split(',') if args.tags else None
     try:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+-r optional-requirements.txt
 coverage==3.7.1
 httmock==1.2.2
 mock==1.0.1

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,0 +1,1 @@
+requests-unixsocket>=0.1.4,<=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests>=2.0.0,<3.0.0
-requests-unixsocket>=0.1.4,<=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 from setuptools import setup
 import sys
 
-install_requires = ['requests>=2.0.0,<3.0.0',
-                    'requests-unixsocket>=0.1.4,<=1.0.0']
+install_requires = ['requests>=2.0.0,<3.0.0']
+
+extras_require = {'unixsocket': ['requests-unixsocket>=0.1.4,<=1.0.0'] }
 
 if sys.version_info < (2, 7, 0):
     install_requires.append('argparse')
@@ -14,6 +15,7 @@ setup(name='consulate',
       maintainer_email="gavinr@aweber.com",
       url="https://consulate.readthedocs.org",
       install_requires=install_requires,
+      extras_require=extras_require,
       license='BSD',
       package_data={'': ['LICENSE', 'README.rst']},
       packages=['consulate', 'consulate.api'],


### PR DESCRIPTION
Considering that UNIX domain socket support requires an add-on module for Requests that has a few compatibility issues with some versions of Requests (notably the version shipped by default with Ubuntu 14.04 LTS), it wouldn't hurt to make it an optional dependency for those who do not need it. This change also loads the UnixSocketRequest adapter when the url scheme is http+unix, not the other way around.

Also fix a mistake introduced in pull request #47 where "no-check" was accidentally included in the set of checks requiring interval to be set.