### PR TITLE
remove cli.py from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ tests/cover
 cover
 docs/_build
 MANIFEST
-cli.py


### PR DESCRIPTION
It looked like a versioned package was added to .gitignore accidentally.