### PR TITLE
Report empty value length as `0` on cli `kv ls -l`

### DIFF
--- a/consulate/cli.py
+++ b/consulate/cli.py
@@ -190,7 +190,10 @@ def kv_ls(consul, args):
     try:
         for key in consul.kv.keys():
             if args.long:
-                print('{0:>14} {1}'.format(len(consul.kv[key]), key))
+                keylen = 0
+                if consul.kv[key]:
+                    keylen = len(consul.kv[key])
+                print('{0:>14} {1}'.format(keylen, key))
             else:
                 print(key)
     except exceptions.ConnectionError:


### PR DESCRIPTION
`consulate kv ls -l` currently throws the following error when a key's value is the empty string:

```
Traceback (most recent call last):
  File "/usr/local/bin/consulate", line 8, in <module>
    load_entry_point('consulate==0.5.1', 'console_scripts', 'consulate')()
  File "/Library/Python/2.7/site-packages/consulate/cli.py", line 285, in main
    KV_ACTIONS[args.action](consul, args)
  File "/Library/Python/2.7/site-packages/consulate/cli.py", line 175, in kv_ls
    print('{0:>14} {1}'.format(len(consul.kv[key]), key))
TypeError: object of type 'NoneType' has no len()
```

This PR changes `consulate kv ls -l` to report `0` for empty keys.