### PR TITLE
Adding run_once functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,20 @@ KV Database Utilities Help:
         rm                  Remove a key from the database
         del                 Deprecated method to remove a key
 
+Locking Operations Help:
+
+.. code:: bash
+
+    usage: consulate [-h] run_once [-i INTERVAL] prefix command
+
+    positional arguments:
+      prefix                the name of the lock which will be held in Consul.
+      command               the command to run
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -i, --interval        hold the lock for INTERVAL seconds
+
 API Usage Examples
 ------------------
 The following examples highlight the usage of Consulate and does not document


### PR DESCRIPTION
Adds the ability to lock a command to the calling process - with the optional limit that the command can only be run once an interval

Usage
---------
To run the echo command once, across a cluster of servers, and to ensure that it's only run once every 60 seconds
```
consulate run_once -i 60 echo_hello 'echo hello'
>>> hello
consulate run_once -i 60 echo_hello 'echo hello'
>>> Last run happened fewer than 60 second ago. Exiting
```

This relies on using consulate's existing ```acquire_lock``` function as well as setting a lock with a unique name, such that subsequent executions can reference the last time the command was run
