### PR TITLE
Added --recurse and --trim to cli kv_get

### DIFF
--- a/consulate/cli.py
+++ b/consulate/cli.py
@@ -53,7 +53,11 @@ KV_PARSERS = [
         [['key'], {'help': 'The key to get'}],
         [['-r', '--recurse'],
          {'help': 'Get all keys prefixed with the specified key',
-          'action': 'store_true'}]]),
+          'action': 'store_true'}],
+        [['-t', '--trim'],
+         {'help': 'Number of levels of prefix to trim from returned key',
+          'type': int,
+          'default': 0}]]),
     ('set', 'Set a key in the database', [
         [['key'], {'help': 'The key to set'}],
         [['value'], {'help': 'The value of the key'}]]),
@@ -213,9 +217,16 @@ def kv_get(consul, args):
     try:
         if args.recurse:
             for key in sorted(consul.kv.find(args.key)):
-                sys.stdout.write("%s\t%s\n" % (key, consul.kv.get(key)))
+                displaykey = key
+                if args.trim:
+                    keyparts = displaykey.split('/')
+                    if (args.trim >= len(keyparts)):
+                        displaykey = keyparts[-1]
+                    else:
+                        displaykey = '/'.join(keyparts[args.trim:])
+                sys.stdout.write('%s\t%s\n' % (displaykey, consul.kv.get(key)))
         else:
-            sys.stdout.write("%s\n" % consul.kv.get(args.key))
+            sys.stdout.write('%s\n' % consul.kv.get(args.key))
     except exceptions.ConnectionError:
         connection_error()
 

--- a/consulate/cli.py
+++ b/consulate/cli.py
@@ -50,8 +50,10 @@ KV_PARSERS = [
         [['path'],
          {'help': 'The path to create'}]]),
     ('get', 'Get a key from the database', [
-        [['key'],
-         {'help': 'The key to get'}]]),
+        [['key'], {'help': 'The key to get'}],
+        [['-r', '--recurse'],
+         {'help': 'Get all keys prefixed with the specified key',
+          'action': 'store_true'}]]),
     ('set', 'Set a key in the database', [
         [['key'], {'help': 'The key to set'}],
         [['value'], {'help': 'The value of the key'}]]),
@@ -209,7 +211,11 @@ def kv_get(consul, args):
 
     """
     try:
-        sys.stdout.write("%s\n" % consul.kv.get(args.key))
+        if args.recurse:
+            for key in sorted(consul.kv.find(args.key)):
+                sys.stdout.write("%s\t%s\n" % (key, consul.kv.get(key)))
+        else:
+            sys.stdout.write("%s\n" % consul.kv.get(args.key))
     except exceptions.ConnectionError:
         connection_error()
 


### PR DESCRIPTION
Added `--recurse` and `--trim` to cli `kv_get` as per issue #56. 

I had trouble getting `argparse` to allow 0/1 args for `--trim` without conflicting with the key. If there's an easy way to do this that I'm overlooking, please let me know.

Here are a few simple examples using `--recurse` and `--trim`:

```bash
$ consulate kv get --recurse test
test/recursive/KEY_1	one
test/recursive/KEY_2	two
test/recursive/KEY_3	three
```

```bash
$ consulate kv get --recurse --trim 0 test
test/recursive/KEY_1	one
test/recursive/KEY_2	two
test/recursive/KEY_3	three
```

```bash
$ consulate kv get --recurse --trim 1 test
recursive/KEY_1	one
recursive/KEY_2	two
recursive/KEY_3	three
```

```bash
$ consulate kv get --recurse --trim 2 test
KEY_1	one
KEY_2	two
KEY_3	three
```

```bash
$ consulate kv get --recurse --trim 3 test
KEY_1	one
KEY_2	two
KEY_3	three
```

```bash
$ consulate kv get --recurse --trim 99999 test
KEY_1	one
KEY_2	two
KEY_3	three
```

