### PR TITLE
fix run_once wrong args + subprocess parsing

### DIFF
--- a/consulate/cli.py
+++ b/consulate/cli.py
@@ -147,7 +147,7 @@ def add_run_once_args(parser):
     run_oncep.add_argument('lock',
                            help='The name of the lock which will be '
                                 'held in Consul.')
-    run_oncep.add_argument('command', nargs=argparse.REMAINDER,
+    run_oncep.add_argument('command_to_run', nargs=argparse.REMAINDER,
                            help='The command to lock')
     run_oncep.add_argument('-i', '--interval', default=None,
                            help='Hold the lock for X seconds')
@@ -401,38 +401,38 @@ def run_once(consul, args):
         import subprocess
 
         session = consul.session.create()
-        if not consul.kv.acquire_lock(args.prefix, session):
+        if not consul.kv.acquire_lock(args.lock, session):
             on_error('Cannot obtain the required lock. Exiting')
         if args.interval:
             now = int(time.time())
-            last_run = consul.kv.get("{0}_last_run".format(args.prefix))
+            last_run = consul.kv.get("{0}_last_run".format(args.lock))
             if str(last_run) not in ['null', 'None'] and \
                     int(last_run) + int(args.interval) > now:
                 sys.stdout.write('Last run happened fewer than {0} '
                                  'second ago. Exiting\n'.format(args.interval))
-                consul.kv.release_lock(args.prefix, session)
+                consul.kv.release_lock(args.lock, session)
                 consul.session.destroy(session)
                 return
-            consul.kv["{0}_last_run".format(args.prefix)] = now
-        consul.kv.release_lock(args.prefix, session)
+            consul.kv["{0}_last_run".format(args.lock)] = now
+        consul.kv.release_lock(args.lock, session)
         consul.session.destroy(session)
 
         # Should the subprocess return an error code, release the lock
         try:
-            subprocess.check_output(args.operation, stderr=subprocess.STDOUT)
+            subprocess.check_output(args.command_to_run, stderr=subprocess.STDOUT)
         # If the subprocess fails
         except subprocess.CalledProcessError as e:
             on_error('"{0}" exited with return code "{1}" '
-                     'and output {2}'.format(args.operation,
+                     'and output {2}'.format(args.command_to_run,
                                              e.returncode,
                                              e.output), 1)
         # If the command doesn't exist
         except OSError as e:
-            on_error('"{0}" command does not exist\n'.format(args.operation), 1)
+            on_error('"{0}" command does not exist\n'.format(args.command_to_run), 1)
 
         # Otherwise
         except Exception as e:
-            on_error('"{0}" exited with error "{1}"'.format(args.operation, e),
+            on_error('"{0}" exited with error "{1}"'.format(args.command_to_run, e),
                      1)
 
     except exceptions.ConnectionError:


### PR DESCRIPTION
Hi @gmr and @hdahme 

The main code was contributed by @hdahme in https://github.com/gmr/consulate/pull/57 but it appears that https://github.com/gmr/consulate/commit/603a1d5dc5b4868e7574e9a30a69994ae9277bf2 cleanup didn't refactor argparse calls in the `run_once` method.

Summary:

- `args.command` is reserved which messes up run_once argparse `command`
- `args.prefix` is not used anymore which blows up on setting the actual lock following refactor to `args.lock`
- args.operation is not used anymore as it was renamed to `args.command`

A little bit confusing but PR itself is clear.

`run_once` is fixed but I'm not getting any output back from the actual command.