### PR TITLE
Added value when acquiring/releasing locks

### DIFF
--- a/consulate/api/kv.py
+++ b/consulate/api/kv.py
@@ -101,7 +101,8 @@ class KV(base.Endpoint):
         :return: bool
 
         """
-        return self._set_item(item, value, params={'acquire': session})
+        response = self._set_item(item, value, params={'acquire': session})
+        return response.body
 
     def delete(self, item, recurse=False):
         """Delete an item from the Key/Value service
@@ -245,7 +246,8 @@ class KV(base.Endpoint):
 
         """
 
-        return self._set_item(item, value, params={'release': session})
+        response = self._set_item(item, value, params={'release': session})
+        return response.body
 
     def set(self, item, value):
         """Set a value in the Key/Value service, using the CAS mechanism

--- a/consulate/api/kv.py
+++ b/consulate/api/kv.py
@@ -98,6 +98,7 @@ class KV(base.Endpoint):
 
         :param str item: The item in the Consul KV database
         :param str session: The session value for the lock
+        :param mixed value: The value to set
         :return: bool
 
         """
@@ -242,6 +243,7 @@ class KV(base.Endpoint):
 
         :param str item: The item in the Consul KV database
         :param str session: The session value for the lock
+        :param mixed value: The value to set
         :return: bool
 
         """
@@ -364,7 +366,7 @@ class KV(base.Endpoint):
             return value
         return value
 
-    def _set_item(self, item, value, flags=None, replace=True, params={}):
+    def _set_item(self, item, value, flags=None, replace=True, params=None):
         """Internal method for setting a key/value pair with flags in the
         Key/Value service
 
@@ -372,6 +374,7 @@ class KV(base.Endpoint):
         :param mixed value: The value to set
         :param int flags: User defined flags to set
         :param bool replace: Overwrite existing values
+        :param dict params: Use provided parameters for query, default cas: index
         :raises: KeyError
 
         """
@@ -383,11 +386,14 @@ class KV(base.Endpoint):
         if index is None:
             return True
 
-        query_params = {'cas': index}
-        query_params.update(params)
+        if params and isinstance(params, dict):
+            query_params = params
+        else:
+            query_params = {'cas': index}
 
         if flags is not None:
             query_params['flags'] = flags
+
         response = self._adapter.put(self._build_uri([item], query_params),
                                      value)
         if not response.status_code == 200 or not response.body:

--- a/consulate/api/kv.py
+++ b/consulate/api/kv.py
@@ -90,7 +90,10 @@ class KV(base.Endpoint):
         :raises: KeyError
 
         """
-        self._set_item(item, value)
+        response = self._set_item(item, value)
+        if not response.body:
+            raise KeyError(
+                'Error setting "{0}" ({1})'.format(item, response.status_code))
 
     def acquire_lock(self, item, session, value=None):
         """Use Consul for locking by specifying the item/key to lock with
@@ -270,9 +273,13 @@ class KV(base.Endpoint):
         :param str item: The key to set
         :param mixed value: The value to set
         :param replace: If True existing value will be overwritten:
+        :raises: KeyError
 
         """
-        self._set_item(item, value, flags, replace)
+        _ = self._set_item(item, value, flags, replace)
+        if not response:
+            raise KeyError(
+                'Error setting "{0}" ({1})'.format(item, response.status_code))
 
     def values(self):
         """Return a list of all of the values in the Key/Value service
@@ -375,7 +382,7 @@ class KV(base.Endpoint):
         :param int flags: User defined flags to set
         :param bool replace: Overwrite existing values
         :param dict params: Use provided parameters for query, default cas: index
-        :raises: KeyError
+        :rtype: response
 
         """
         value = self._prepare_value(value)
@@ -397,5 +404,6 @@ class KV(base.Endpoint):
         response = self._adapter.put(self._build_uri([item], query_params),
                                      value)
         if not response.status_code == 200 or not response.body:
-            raise KeyError(
-                'Error setting "{0}" ({1})'.format(item, response.status_code))
+            return response
+
+        return response

--- a/consulate/api/kv.py
+++ b/consulate/api/kv.py
@@ -92,7 +92,7 @@ class KV(base.Endpoint):
         """
         self._set_item(item, value)
 
-    def acquire_lock(self, item, session):
+    def acquire_lock(self, item, value, session):
         """Use Consul for locking by specifying the item/key to lock with
         and a session value for removing the lock.
 

--- a/consulate/api/kv.py
+++ b/consulate/api/kv.py
@@ -7,6 +7,7 @@ from consulate import utils
 
 
 class KV(base.Endpoint):
+
     """The :py:class:`consul.api.KV` class implements a :py:class:`dict` like
     interface for working with the Key/Value service. Simply use items on the
     :py:class:`consulate.Session` like you would with a :py:class:`dict` to
@@ -100,7 +101,7 @@ class KV(base.Endpoint):
         :return: bool
 
         """
-        return self._put_response_body([item], {'acquire': session})
+        return self._set_item(item, value, params={'acquire': session})
 
     def delete(self, item, recurse=False):
         """Delete an item from the Key/Value service
@@ -235,7 +236,7 @@ class KV(base.Endpoint):
         return [(item['Key'], item['Flags'], item['Value'])
                 for item in self._get_all_items()]
 
-    def release_lock(self, item, session):
+    def release_lock(self, item, value, session):
         """Release an existing lock from the Consul KV database.
 
         :param str item: The item in the Consul KV database
@@ -243,7 +244,8 @@ class KV(base.Endpoint):
         :return: bool
 
         """
-        return self._put_response_body([item], {'release': session})
+
+        return self._set_item(item, value, params={'release': session})
 
     def set(self, item, value):
         """Set a value in the Key/Value service, using the CAS mechanism
@@ -360,7 +362,7 @@ class KV(base.Endpoint):
             return value
         return value
 
-    def _set_item(self, item, value, flags=None, replace=True):
+    def _set_item(self, item, value, flags=None, replace=True, params={}):
         """Internal method for setting a key/value pair with flags in the
         Key/Value service
 
@@ -380,6 +382,8 @@ class KV(base.Endpoint):
             return True
 
         query_params = {'cas': index}
+        query_params.update(params)
+
         if flags is not None:
             query_params['flags'] = flags
         response = self._adapter.put(self._build_uri([item], query_params),

--- a/consulate/api/kv.py
+++ b/consulate/api/kv.py
@@ -92,7 +92,7 @@ class KV(base.Endpoint):
         """
         self._set_item(item, value)
 
-    def acquire_lock(self, item, value, session):
+    def acquire_lock(self, item, session, value=None):
         """Use Consul for locking by specifying the item/key to lock with
         and a session value for removing the lock.
 
@@ -236,7 +236,7 @@ class KV(base.Endpoint):
         return [(item['Key'], item['Flags'], item['Value'])
                 for item in self._get_all_items()]
 
-    def release_lock(self, item, value, session):
+    def release_lock(self, item, session, value=None):
         """Release an existing lock from the Consul KV database.
 
         :param str item: The item in the Consul KV database

--- a/consulate/api/kv.py
+++ b/consulate/api/kv.py
@@ -276,7 +276,7 @@ class KV(base.Endpoint):
         :raises: KeyError
 
         """
-        _ = self._set_item(item, value, flags, replace)
+        response = self._set_item(item, value, flags, replace)
         if not response:
             raise KeyError(
                 'Error setting "{0}" ({1})'.format(item, response.status_code))


### PR DESCRIPTION
Hi,

Wanted to take a stab at #63. Add a value to the put calls for acquire/release locks for KV. Instead of _put_request_body, referencing KV _set_item. Added additional parameter to method update dictionary for those calls.