### PR TITLE
Raise server-error exception when setting a key fails due to a server error

### DIFF
--- a/consulate/api/kv.py
+++ b/consulate/api/kv.py
@@ -3,7 +3,7 @@ Consul KV Endpoint Access
 
 """
 from consulate.api import base
-from consulate import utils
+from consulate import utils, exceptions
 
 
 class KV(base.Endpoint):
@@ -385,5 +385,8 @@ class KV(base.Endpoint):
         response = self._adapter.put(self._build_uri([item], query_params),
                                      value)
         if not response.status_code == 200 or not response.body:
+            if response.status_code == 500:
+                raise exceptions.ServerError(
+                    response.body or 'Internal Consul server error')
             raise KeyError(
                 'Error setting "{0}" ({1})'.format(item, response.status_code))

--- a/consulate/exceptions.py
+++ b/consulate/exceptions.py
@@ -24,3 +24,8 @@ class NotFound(ConsulateException):
 
     """
     pass
+
+
+class ServerError(ConsulateException):
+    """An internal Consul server error occurred"""
+    pass


### PR DESCRIPTION
The current error when setting a key fails due to a Consul server error does not shed much light on why the set failed

```
(consulate) fredric$ consulate kv set foo bar
...
KeyError: 'Error setting "foo" (500)'
```

This PR adds a `ServerError` exception which gets raised when the set fails with a 500 status, and sets the exception arg to be the error message from the server

```
(consulate) fredric$ consulate kv set foo bar
...
consulate.exceptions.ServerError: No cluster leader
```