### PR TITLE
Don't try to b64decode null values on kv restore

### DIFF
--- a/consulate/cli.py
+++ b/consulate/cli.py
@@ -306,7 +306,7 @@ def kv_restore(consul, args):
                 row['Value'] = base64.b64decode(row['Value'])
             row = [row['Key'], row['Flags'], row['Value']]
 
-        if args.base64:
+        if args.base64 and row[2] is not None:
             row[2] = base64.b64decode(row[2])
 
         # Here's an awesome thing to make things work


### PR DESCRIPTION
This should address #68. When encountering rows with a null value during a kv restore, leave them null and move on rather than trying to b64decode them (since trying to b64decode `None` fails).