### PR TITLE
Prevent empty KV values from being set as string "null"

### DIFF
--- a/consulate/adapters.py
+++ b/consulate/adapters.py
@@ -37,7 +37,7 @@ def prepare_data(fun):
         if kwargs.get('data'):
             if not utils.is_string(kwargs.get('data')):
                 kwargs['data'] = json.dumps(kwargs['data'])
-        elif len(args) == 3 and not utils.is_string(args[2]):
+        elif len(args) == 3 and not (utils.is_string(args[2]) or args[2] is None):
             args = args[0], args[1], json.dumps(args[2])
         return fun(*args, **kwargs)
 


### PR DESCRIPTION
When setting key(s) with values of `None`, the values are being incorrectly set as string `"null"`. This is also occurring with `kv backup` and `kv restore`.  If the backup JSON has any values of `null` (an empty key), those values are being restored as `"null"`.

Before patch:
```python
>>> consul.kv.set('mykey', None)
>>> consul.kv.get_record('mykey')
{u'LockIndex': 0, u'ModifyIndex': 3834, u'Value': u'null', u'Flags': 0, u'Key': u'mykey', u'CreateIndex': 3834}
```
After patch:
```python
>>> consul.kv.set('myNewKey', None)
>>> consul.kv.get_record('myNewKey')
{u'LockIndex': 0, u'ModifyIndex': 3851, u'Value': None, u'Flags': 0, u'Key': u'myNewKey', u'CreateIndex': 3851}
```

