### PR TITLE
Expose Requests verify= parameter

### DIFF
--- a/consulate/__init__.py
+++ b/consulate/__init__.py
@@ -53,6 +53,7 @@ class Consul(object):
     :param str scheme: Specify the scheme (Default: http)
     :param class adapter: Specify to override the request adapter
         (Default: :py:class:`consulate.adapters.Request`)
+    :param bool/str verify: Specify how to verify TLS certificates
 
     """
 
@@ -62,10 +63,11 @@ class Consul(object):
                  datacenter=None,
                  token=None,
                  scheme=DEFAULT_SCHEME,
-                 adapter=None):
+                 adapter=None,
+                 verify=True):
         """Create a new instance of the Consul class"""
         base_uri = self._base_uri(scheme, host, port)
-        self._adapter = adapter() if adapter else adapters.Request()
+        self._adapter = adapter() if adapter else adapters.Request(verify=verify)
         self._acl = api.ACL(base_uri, self._adapter, datacenter, token)
         self._agent = api.Agent(base_uri, self._adapter, datacenter, token)
         self._catalog = api.Catalog(base_uri, self._adapter, datacenter, token)

--- a/consulate/adapters.py
+++ b/consulate/adapters.py
@@ -47,7 +47,7 @@ def prepare_data(fun):
 class Request(object):
     """The Request adapter class"""
 
-    def __init__(self, timeout=None):
+    def __init__(self, timeout=None, verify=True):
         """
         Create a new request adapter instance.
 
@@ -55,6 +55,7 @@ class Request(object):
             to consul.
         """
         self.session = requests.Session()
+        self.session.verify = verify
         self.timeout = timeout
 
     def delete(self, uri):


### PR DESCRIPTION
Currently there doesn't seem an obvious way to point Consulate to a single CA certificate or bundle of them for the purposes of verifying the certificate that Consul presents over HTTPS.

The only way I've managed to do this is by using the fact that consulate is using Requests under the hood so I can set the `$REQUESTS_CA_BUNDLE` environment variable however that alters the behaviour globally for any other Requests-using module in my code; I'd rather have explicit control per-module.

This PR exposes the `verify=` option that Requests supports that allows a boolean `True` or `False` as well as pointing to either a file containing one or more certificates or a directory of certificates. With this I'm able to connect to my test Consul with a self-signed certificate.