### PR TITLE
Expose Requests TLS options

### DIFF
--- a/consulate/__init__.py
+++ b/consulate/__init__.py
@@ -53,6 +53,7 @@ class Consul(object):
     :param str scheme: Specify the scheme (Default: http)
     :param class adapter: Specify to override the request adapter
         (Default: :py:class:`consulate.adapters.Request`)
+    :param bool/str verify: Specify how to verify TLS certificates
 
     """
 
@@ -62,10 +63,11 @@ class Consul(object):
                  datacenter=None,
                  token=None,
                  scheme=DEFAULT_SCHEME,
-                 adapter=None):
+                 adapter=None,
+                 verify=True):
         """Create a new instance of the Consul class"""
         base_uri = self._base_uri(scheme, host, port)
-        self._adapter = adapter() if adapter else adapters.Request()
+        self._adapter = adapter() if adapter else adapters.Request(verify=verify)
         self._acl = api.ACL(base_uri, self._adapter, datacenter, token)
         self._agent = api.Agent(base_uri, self._adapter, datacenter, token)
         self._catalog = api.Catalog(base_uri, self._adapter, datacenter, token)

--- a/consulate/__init__.py
+++ b/consulate/__init__.py
@@ -54,6 +54,7 @@ class Consul(object):
     :param class adapter: Specify to override the request adapter
         (Default: :py:class:`consulate.adapters.Request`)
     :param bool/str verify: Specify how to verify TLS certificates
+    :param tuple cert: Specify client TLS certificate and key files
 
     """
 
@@ -64,10 +65,11 @@ class Consul(object):
                  token=None,
                  scheme=DEFAULT_SCHEME,
                  adapter=None,
-                 verify=True):
+                 verify=True,
+                 cert=None):
         """Create a new instance of the Consul class"""
         base_uri = self._base_uri(scheme, host, port)
-        self._adapter = adapter() if adapter else adapters.Request(verify=verify)
+        self._adapter = adapter() if adapter else adapters.Request(verify=verify, cert=cert)
         self._acl = api.ACL(base_uri, self._adapter, datacenter, token)
         self._agent = api.Agent(base_uri, self._adapter, datacenter, token)
         self._catalog = api.Catalog(base_uri, self._adapter, datacenter, token)

--- a/consulate/adapters.py
+++ b/consulate/adapters.py
@@ -47,7 +47,7 @@ def prepare_data(fun):
 class Request(object):
     """The Request adapter class"""
 
-    def __init__(self, timeout=None, verify=True):
+    def __init__(self, timeout=None, verify=True, cert=None):
         """
         Create a new request adapter instance.
 
@@ -56,6 +56,7 @@ class Request(object):
         """
         self.session = requests.Session()
         self.session.verify = verify
+        self.session.cert = cert
         self.timeout = timeout
 
     def delete(self, uri):

--- a/consulate/adapters.py
+++ b/consulate/adapters.py
@@ -47,7 +47,7 @@ def prepare_data(fun):
 class Request(object):
     """The Request adapter class"""
 
-    def __init__(self, timeout=None):
+    def __init__(self, timeout=None, verify=True):
         """
         Create a new request adapter instance.
 
@@ -55,6 +55,7 @@ class Request(object):
             to consul.
         """
         self.session = requests.Session()
+        self.session.verify = verify
         self.timeout = timeout
 
     def delete(self, uri):


### PR DESCRIPTION
I've extended @bodgit's PR #76 to also expose the cert= parameter in requests. This allows the use of client certificates when Consul server's verify_incoming setting is set to true. 