### PR TITLE
Build single universal wheel for both py2 and py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
     - 3.3
     - 3.4
 before_install:
-    - curl -L -o /tmp/0.5.2_linux_amd64.zip https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip
+    - curl -L -o /tmp/0.5.2_linux_amd64.zip https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip
     - unzip /tmp/0.5.2_linux_amd64.zip
     - ./consul agent -config-file consul-test.json > /tmp/consul.log &
     - pip install codecov

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
Travis deploy is currently publishing sdist and bdist_wheel:

```
consulate-0.6.0-py2-none-any.whl
consulate-0.6.0.tar.gz
```

Although consulate is tested on both py2 and py3, the wheel file is python2 only. This PR adds a setup.cfg file to make bdist_wheel build a wheel that can be installed on both python2 and python3

(this PR is based on #84 to avoid unrelated test failures)
