### PR TITLE
Update docstring urls for the documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tests/cover
 cover
 docs/_build
 MANIFEST
+venv

--- a/consulate/__init__.py
+++ b/consulate/__init__.py
@@ -85,7 +85,7 @@ class Consul(object):
     @property
     def acl(self):
         """Access the Consul
-        `ACL <https://www.consul.io/docs/agent/http.html#acl>`_ API
+        `ACL <https://www.consul.io/docs/agent/http/acl.html>`_ API
 
         :rtype: :py:class:`consulate.api.acl.ACL`
 
@@ -95,7 +95,7 @@ class Consul(object):
     @property
     def agent(self):
         """Access the Consul
-        `Agent <https://www.consul.io/docs/agent/http.html#agent>`_ API
+        `Agent <https://www.consul.io/docs/agent/http/agent.html>`_ API
 
         :rtype: :py:class:`consulate.api.agent.Agent`
 
@@ -105,7 +105,7 @@ class Consul(object):
     @property
     def catalog(self):
         """Access the Consul
-        `Catalog <https://www.consul.io/docs/agent/http.html#catalog>`_ API
+        `Catalog <https://www.consul.io/docs/agent/http/catalog.html>`_ API
 
         :rtype: :py:class:`consulate.api.catalog.Catalog`
 
@@ -115,7 +115,7 @@ class Consul(object):
     @property
     def event(self):
         """Access the Consul
-        `Events <https://www.consul.io/docs/agent/http.html#events>`_ API
+        `Events <https://www.consul.io/docs/agent/http/event.html>`_ API
 
         :rtype: :py:class:`consulate.api.event.Event`
 
@@ -125,7 +125,7 @@ class Consul(object):
     @property
     def health(self):
         """Access the Consul
-        `Health <https://www.consul.io/docs/agent/http.html#health>`_ API
+        `Health <https://www.consul.io/docs/agent/http/health.html>`_ API
 
         :rtype: :py:class:`consulate.api.health.Health`
 
@@ -135,7 +135,7 @@ class Consul(object):
     @property
     def kv(self):
         """Access the Consul
-        `KV <https://www.consul.io/docs/agent/http.html#kv>`_ API
+        `KV <https://www.consul.io/docs/agent/http/kv.html>`_ API
 
         :rtype: :py:class:`consulate.api.kv.KV`
 
@@ -145,7 +145,7 @@ class Consul(object):
     @property
     def lock(self):
         """Wrapper for easy :class:`~consulate.api.kv.KV` locks.
-
+        `Semaphore <https://www.consul.io/docs/guides/semaphore.html>` _Guide
         Example:
 
         .. code:: python
@@ -165,7 +165,7 @@ class Consul(object):
     @property
     def session(self):
         """Access the Consul
-        `Session <https://www.consul.io/docs/agent/http.html#session>`_ API
+        `Session <https://www.consul.io/docs/agent/http/session.html>`_ API
 
         :rtype: :py:class:`consulate.api.session.Session`
 
@@ -175,7 +175,7 @@ class Consul(object):
     @property
     def status(self):
         """Access the Consul
-        `Status <https://www.consul.io/docs/agent/http.html#status>`_ API
+        `Status <https://www.consul.io/docs/agent/http/status.html>`_ API
 
         :rtype: :py:class:`consulate.api.status.Status`
 

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -29,8 +29,8 @@ class ACL(base.Endpoint):
         the create endpoint.
 
         ``rules`` is a HCL string defining the rule policy. See
-        `https://consul.io/docs/internals/acl.html`_ for more information on
-        defining rules.
+        `Internals on <https://www.consul.io/docs/internals/acl.html>`_ ACL
+        for more information on defining rules.
 
         The call to create will return the ID of the new ACL.
 


### PR DESCRIPTION
When reading http://consulate.readthedocs.io/en/stable/consul.html I noticed https://www.consul.io/docs/agent/http.html#acl only links to the main page so I guess they modified their docs structure to subpages, hence the PR for https://www.consul.io/docs/agent/http/acl.html instead.
