### PR TITLE
Handle None value in python 3 same as done below in python 2

### DIFF
--- a/consulate/cli.py
+++ b/consulate/cli.py
@@ -295,7 +295,7 @@ def kv_backup(consul, args):
     if args.base64:
         if utils.PYTHON3:
             records = [(k, f, str(base64.b64encode(utils.maybe_encode(v)),
-                                  'ascii'))
+                                  'ascii') if v else v)
                        for k, f, v in records]
         else:
             records = [(k, f, base64.b64encode(v) if v else v)


### PR DESCRIPTION
When using base64 option it would fail when encountering None values. This corrects the syntax to be exactly what was done with python2 to handle the same