### PR TITLE
fix http method not allowed for consul verison 1.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-    - 2.6
     - 2.7
     - pypy
     - 3.3
@@ -12,7 +11,6 @@ before_install:
     - ./consul agent -config-file consul-test.json > /tmp/consul.log &
     - pip install codecov
 install:
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors argparse unittest2; fi
     - pip install -r dev-requirements.txt
 script: nosetests --with-coverage --cover-package=consulate --cover-branches
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
     - 3.3
     - 3.4
 before_install:
-    - curl -L -o /tmp/0.5.2_linux_amd64.zip https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip
-    - unzip /tmp/0.5.2_linux_amd64.zip
+    - curl -L -o /tmp/1.0.2_linux_amd64.zip https://releases.hashicorp.com/consul/1.0.2/consul_1.0.2_linux_amd64.zip?_ga=2.175144422.533311668.1514167042-454230918.1511333239
+    - unzip /tmp/1.0.2_linux_amd64.zip
     - ./consul agent -config-file consul-test.json > /tmp/consul.log &
     - pip install codecov
 install:

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -63,6 +63,8 @@ class ACL(base.Endpoint):
         #     raise exceptions.Forbidden(response.body)
         if response.status_code == 404:
             raise exceptions.NotFound(response.body)
+        elif response.status_code == 403:
+            raise exceptions.Forbidden(response.body)
         return response.body.get('ID')
 
     def destroy(self, acl_id):
@@ -90,8 +92,9 @@ class ACL(base.Endpoint):
         :raises: consulate.exceptions.NotFound
 
         """
+
         result = self._get(['info', acl_id], raise_on_404=True)
-        if result is None:
+        if not result:
             raise exceptions.NotFound()
         return result
 

--- a/consulate/api/agent.py
+++ b/consulate/api/agent.py
@@ -126,7 +126,7 @@ class Agent(base.Endpoint):
             :param str check_id: The check id
 
             """
-            return self._get_no_response_body(['deregister', check_id])
+            return self._put_no_response_body(['deregister', check_id])
 
         def ttl_pass(self, check_id):
             """This endpoint is used with a check that is of the TTL type.
@@ -136,7 +136,7 @@ class Agent(base.Endpoint):
             :param str check_id: The check id
 
             """
-            return self._get_no_response_body(['pass', check_id])
+            return self._put_no_response_body(['pass', check_id])
 
         def ttl_warn(self, check_id):
             """This endpoint is used with a check that is of the TTL type.
@@ -146,7 +146,7 @@ class Agent(base.Endpoint):
             :param str check_id: The check id
 
             """
-            return self._get_no_response_body(['warn', check_id])
+            return self._put_no_response_body(['warn', check_id])
 
         def ttl_fail(self, check_id):
             """This endpoint is used with a check that is of the TTL type.
@@ -156,7 +156,7 @@ class Agent(base.Endpoint):
             :param str check_id: The check id
 
             """
-            return self._get_no_response_body(['fail', check_id])
+            return self._put_no_response_body(['fail', check_id])
 
     class Service(base.Endpoint):
         """One of the main goals of service discovery is to provide a catalog
@@ -243,7 +243,7 @@ class Agent(base.Endpoint):
             :rtype: bool
 
             """
-            return self._get_no_response_body(['deregister', service_id])
+            return self._put_no_response_body(['deregister', service_id])
 
     def checks(self):
         """return the all the checks that are registered with the local agent.
@@ -267,7 +267,7 @@ class Agent(base.Endpoint):
         node into the left state allows its old entries to be removed.
 
         """
-        return self._get_no_response_body(['force-leave', node])
+        return self._put_no_response_body(['force-leave', node])
 
     def join(self, address, wan=False):
         """This endpoint is hit with a GET and is used to instruct the agent
@@ -281,7 +281,7 @@ class Agent(base.Endpoint):
 
         """
         query_params = {'wan': 1} if wan else None
-        return self._get_no_response_body(['join', address], query_params)
+        return self._put_no_response_body(['join', address], query_params)
 
     def members(self):
         """Returns the members the agent sees in the cluster gossip pool.

--- a/tests/acceptance-tests.py
+++ b/tests/acceptance-tests.py
@@ -74,8 +74,8 @@ class TestACL(BaseTestCase):
         self.assertTrue(self.consul.acl.destroy(acl_id))
 
     @generate_key
-    def test_clone_not_found(self, key):
-        self.assertRaises(consulate.NotFound, self.consul.acl.clone, key)
+    def test_clone_forbidden(self, key):
+        self.assertRaises(consulate.Forbidden, self.consul.acl.clone, key)
 
     @generate_key
     def test_info_not_found(self, key):


### PR DESCRIPTION
Consul has now hit version 1.0.3, and they have made the accepted HTTP verbs for various endpoints much stricter. some functions don't work as they use GET requests and those endpoints now only support PUT requests. 