### PR TITLE
Issue #97: Add version to cli

### DIFF
--- a/consulate/cli.py
+++ b/consulate/cli.py
@@ -244,6 +244,9 @@ def parse_cli_args():
                         default=None,
                         help='The datacenter to specify for the connection')
     parser.add_argument('--token', default=None, help='ACL token')
+    parser.add_argument('--version', action='version',
+                        version=consulate.__version__,
+                        help='Current consulate version')
 
     sparser = parser.add_subparsers(title='Commands', dest='command')
     add_acl_args(sparser)


### PR DESCRIPTION
Added the ability to see the version from the cli. Not sure how to show the build info or if that is needed. If needed, maybe git_version will be able to show that information? Not sure what your thoughts are.

Also made minor suggestion for setup.py so you didnt have to bump the version in multiple places. 