### PR TITLE
Add support for Node Metadata in API and Health classes 

### DIFF
--- a/consulate/api/catalog.py
+++ b/consulate/api/catalog.py
@@ -19,7 +19,8 @@ class Catalog(base.Endpoint):
     def register(self, node, address,
                  datacenter=None,
                  service=None,
-                 check=None):
+                 check=None,
+                 node_meta=None):
         """A a low level mechanism for directly registering or updating
         entries in the catalog. It is usually recommended to use the agent
         local endpoints, as they are simpler and perform anti-entropy.
@@ -76,11 +77,20 @@ class Catalog(base.Endpoint):
                 'ServiceID': 'redis1'
             }
 
+        Example node_meta dict:
+
+        .. code:: python
+
+            'NodeMeta': {
+                'somekey': 'somevalue'
+            }
+
         :param str node: The node name
         :param str address: The node address
         :param str datacenter: The optional node datacenter
         :param dict service: An optional node service
         :param dict check: An optional node check
+        :param dict node_meta: Optional node metadata
         :rtype: bool
 
         """
@@ -91,6 +101,8 @@ class Catalog(base.Endpoint):
             payload['Service'] = service
         if check:
             payload['Check'] = check
+        if node_meta:
+            payload['NodeMeta'] = node_meta
 
         return self._put_response_body(['register'], None, payload)
 
@@ -141,13 +153,15 @@ class Catalog(base.Endpoint):
         """
         return self._get(['node', node_id])
 
-    def nodes(self):
+    def nodes(self, node_meta=None):
         """Return all of the nodes for the current datacenter.
 
+        :param str node_meta: Desired node metadata
         :rtype: list
 
         """
-        return self._get_list(['nodes'])
+        query_params = {'node-meta': node_meta} if node_meta else {}
+        return self._get_list(['nodes'], query_params)
 
     def service(self, service_id):
         """Return the service details for the given service

--- a/consulate/api/health.py
+++ b/consulate/api/health.py
@@ -14,14 +14,16 @@ class Health(base.Endpoint):
 
     """
 
-    def checks(self, service_id):
+    def checks(self, service_id, node_meta=None):
         """Return checks for the given service.
 
         :param str service_id: The service ID
+        :param str node_meta: Filter checks using node metadata
         :rtype: list
 
         """
-        return self._get_list(['checks', service_id])
+        query_params = {'node-meta': node_meta} if node_meta else {}
+        return self._get_list(['checks', service_id], query_params)
 
     def node(self, node_id):
         """Return the health info for a given node.
@@ -32,10 +34,11 @@ class Health(base.Endpoint):
         """
         return self._get_list(['node', node_id])
 
-    def service(self, service_id, tag=None, passing=None):
+    def service(self, service_id, tag=None, passing=None, node_meta=None):
         """Returns the nodes and health info of a service
 
         :param str service_id: The service ID
+        :param str node_meta: Filter services using node metadata
         :rtype: list
 
         """
@@ -45,6 +48,8 @@ class Health(base.Endpoint):
             query_params['tag'] = tag
         if passing:
             query_params['passing'] = ''
+        if node_meta:
+            query_params['node-meta'] = node_meta
 
         return self._get_list(['service', service_id],
                               query_params=query_params)

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -24,6 +24,7 @@ Version History
     - Address Python 2.6 incompatibility with the consulate cli and null data (#62, #61) - Wayne Walker
     - Added :class:`~consulate.api.lock.Lock` class for easier lock acquisition
     - New CLI feature to backup and restore ACLs (#71)
+    - Added support for node metadata in :class:`consulate.Consul.api.catalog` & :class:`~consulate.Comsul.api.health` 
 
  - 0.6.0 - released *2015-07-22*
   - Added --recurse and --trim to cli kv_get (#58) - Matt Walker


### PR DESCRIPTION
This PR adds support for Node Metadata in the API and Health classes.

When registering or updating nodes via API calls, metadata can be supplied as a registration parameter via a dictionary. This metadata can then be used to filter nodes when creating a list, or to filter service data and check data.

https://www.consul.io/api/catalog.html

https://www.consul.io/api/health.html

This is useful when registering nodes via an AWS lambda function in highly dynamic environments; ASG ID, instance ID, and other AWS metadata can be registered with consul. Nodes, services, and health can then be filtered by the metadata.

Code passes unit tests, and syntax tests, though the existing unit tests do not seem to have a lot of coverage for API call parameters.

Exploratory tests worked as expected, with easy registration and filtering of nodes via metadata.