### PR TITLE
Acl 1.5.0

### DIFF
--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -276,6 +276,18 @@ class ACL(base.Endpoint):
                                roles=roles,
                                service_identities=service_identities)))
 
+    def clone_token(self, accessor_id, description=None):
+        """Clone a token by the accessor_id.
+
+        :param str accessor_id: A UUID for accessing the token.
+        :param str description: A human-readable description of the token.
+        :param rtype: dict
+
+        """
+        return self._put_response_body(
+            ["token", accessor_id, "clone"], {},
+            dict(model.ACLToken(description=description)))
+
     def delete_token(self, accessor_id):
         """Delete an existing token with the given AcccessorID.
 

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -16,7 +16,6 @@ class ACL(base.Endpoint):
     tokens.
 
     """
-
     def read_self_token(self):
         """Retrieve the currently used token.
         :param rtype: dict
@@ -39,35 +38,50 @@ class ACL(base.Endpoint):
         """
         return self._get(["policy", id])
 
-    def create_policy(self, name, datacenters=None, description=None, rules=None):
+    def create_policy(self,
+                      name,
+                      datacenters=None,
+                      description=None,
+                      rules=None):
         """Create policy with name given and rules.
 
         :param str name: name of the policy
-        :param list() datacenters: A list of datacenters to filter the policy for. Default is an empty list for all datacenters.
+        :param list() datacenters: A list of datacenters to filter on policy.
         :param str description: Human readable description of the policy.
-        :param str rules: A json serializable string for the ACL rules to define for the policy.
+        :param str rules: A json serializable string for ACL rules.
         :param rtype: dict
 
         """
-        return self._put_response_body(["policy"], {}, dict(
-            model.ACLPolicy(name=name, datacenters=datacenters,
-                            description=description, rules=rules)
-        ))
+        return self._put_response_body(["policy"], {},
+                                       dict(
+                                           model.ACLPolicy(
+                                               name=name,
+                                               datacenters=datacenters,
+                                               description=description,
+                                               rules=rules)))
 
-    def update_policy(self, id, name, datacenters=None, description=None, rules=None):
+    def update_policy(self,
+                      id,
+                      name,
+                      datacenters=None,
+                      description=None,
+                      rules=None):
         """Update policy with id given.
         :param str id: A UUID for the policy to update.
         :param str name: name of the policy
-        :param list() datacenters: A list of datacenters to filter the policy for. Default is an empty list for all datacenters.
+        :param list() datacenters: A list of datacenters to filter on policy.
         :param str description: Human readable description of the policy.
-        :param str rules: A json serializable string for the ACL rules to define for the policy.
+        :param str rules: A json serializable string for ACL rules.
         :param rtype: dict
 
         """
-        return self._put_response_body(["policy", id], {}, dict(
-            model.ACLPolicy(name=name, datacenters=datacenters,
-                            description=description, rules=rules)
-        ))
+        return self._put_response_body(["policy", id], {},
+                                       dict(
+                                           model.ACLPolicy(
+                                               name=name,
+                                               datacenters=datacenters,
+                                               description=description,
+                                               rules=rules)))
 
     def delete_policy(self, id):
         """Delete an existing policy with the given ID.
@@ -85,19 +99,26 @@ class ACL(base.Endpoint):
         """
         return self._get(["roles"])
 
-    def create_role(self, name, description=None, policies=None, service_identities=None):
-        """Create an ACL role from a list of policies and or service service_identities.
-        :param str name: The name of the ACL role. Must be unique alphanumeral and dashes and underscores.
+    def create_role(self,
+                    name,
+                    description=None,
+                    policies=None,
+                    service_identities=None):
+        """Create an ACL role from a list of policies or service identities.
+        :param str name: The name of the ACL role. Must be unique.
         :param str description: The description of the ACL role.
         :param PolicyLinks policies: An array of PolicyLink.
-        :param ServiceIdentities service_identities: An array of ServiceIdentity.
+        :param ServiceIdentities service_identities: A ServiceIdentity array.
         :param rtype: dict
 
         """
-        return self._put_response_body(["role"], {}, dict(
-            model.ACLPolicy(name=name, description=description,
-                            policies=policies, service_identities=service_identities)
-        ))
+        return self._put_response_body(
+            ["role"], {},
+            dict(
+                model.ACLPolicy(name=name,
+                                description=description,
+                                policies=policies,
+                                service_identities=service_identities)))
 
     # NOTE: Everything below here is deprecated post consul-1.4.0.
 
@@ -154,9 +175,11 @@ class ACL(base.Endpoint):
         :raises: consulate.exceptions.Forbidden
 
         """
-        return self._put_response_body(
-            ['create'], {}, dict(model.ACL(
-                name=name, type=acl_type, rules=rules)))['ID']
+        return self._put_response_body(['create'], {},
+                                       dict(
+                                           model.ACL(name=name,
+                                                     type=acl_type,
+                                                     rules=rules)))['ID']
 
     def clone(self, acl_id):
         """Clone an existing ACL returning the new ACL ID
@@ -232,6 +255,9 @@ class ACL(base.Endpoint):
         :raises: consulate.exceptions.Forbidden
 
         """
-        return self._put_response_body(
-            ['update'], {}, dict(model.ACL(
-                id=acl_id, name=name, type=acl_type, rules=rules)))['ID']
+        return self._put_response_body(['update'], {},
+                                       dict(
+                                           model.ACL(id=acl_id,
+                                                     name=name,
+                                                     type=acl_type,
+                                                     rules=rules)))['ID']

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -16,6 +16,40 @@ class ACL(base.Endpoint):
     tokens.
 
     """
+
+    def read_self_token(self):
+        """ Retrieve the currently used token.
+        """
+        return self._get(["token", "self"])
+
+    def list_policies(self):
+        """ List all policies available in cluster
+        """
+        return self._get(["policies"])
+
+    def create_policy(self, name, datacenters=None, description=None, rules=None):
+        """ Create policy with name given and rules.
+
+        :param str name: name of the policy
+        :param list() datacenters: A list of datacenters to filter the policy for. Default is an empty list for all datacenters.
+        :param str description: Human readable description of the policy.
+        :param str rules: A json serializable string for the ACL rules to define for the policy.
+        """
+
+        return self._put_response_body(["policy"], {}, dict(
+            model.ACLPolicy(name=name, datacenters=datacenters,
+                            description=description, rules=rules)
+        ))
+
+    def read_policy(self, id):
+        """ Read an existing policy with the given ID.
+        :param str id: The ID of the policy.
+        """
+
+        return self._get(["policy", id])
+
+    # NOTE: Everything below here is deprecated post consul-1.4.0.
+
     def bootstrap(self):
         """This endpoint does a special one-time bootstrap of the ACL system,
         making the first management token if the acl_master_token is not

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -27,6 +27,12 @@ class ACL(base.Endpoint):
         """
         return self._get(["policies"])
 
+    def read_policy(self, id):
+        """ Read an existing policy with the given ID.
+        :param str id: The ID of the policy.
+        """
+        return self._get(["policy", id])
+
     def create_policy(self, name, datacenters=None, description=None, rules=None):
         """ Create policy with name given and rules.
 
@@ -35,18 +41,23 @@ class ACL(base.Endpoint):
         :param str description: Human readable description of the policy.
         :param str rules: A json serializable string for the ACL rules to define for the policy.
         """
-
         return self._put_response_body(["policy"], {}, dict(
             model.ACLPolicy(name=name, datacenters=datacenters,
                             description=description, rules=rules)
         ))
 
-    def read_policy(self, id):
-        """ Read an existing policy with the given ID.
-        :param str id: The ID of the policy.
+    def update_policy(self, id, datacenters=None, description=None, name=None, rules=None):
+        """ Update policy with id given.
+        :param str id: A UUID for the policy to update.
+        :param list() datacenters: A list of datacenters to filter the policy for. Default is an empty list for all datacenters.
+        :param str description: Human readable description of the policy.
+        :param str name: name of the policy
+        :param str rules: A json serializable string for the ACL rules to define for the policy.
         """
-
-        return self._get(["policy", id])
+        return self._put_response_body(["policy", id], {}, dict(
+            model.ACLPolicy(name=name, datacenters=datacenters,
+                            description=description, rules=rules)
+        ))
 
     def delete_policy(self, id):
         """ Delete an existing policy with the given ID.

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -18,41 +18,51 @@ class ACL(base.Endpoint):
     """
 
     def read_self_token(self):
-        """ Retrieve the currently used token.
+        """Retrieve the currently used token.
+        :param rtype: dict
+
         """
         return self._get(["token", "self"])
 
     def list_policies(self):
-        """ List all ACL policies available in cluster
+        """List all ACL policies available in cluster.
+        :param rtype: list
+
         """
         return self._get(["policies"])
 
     def read_policy(self, id):
-        """ Read an existing policy with the given ID.
+        """Read an existing policy with the given ID.
         :param str id: The ID of the policy.
+        :param rtype: dict
+
         """
         return self._get(["policy", id])
 
     def create_policy(self, name, datacenters=None, description=None, rules=None):
-        """ Create policy with name given and rules.
+        """Create policy with name given and rules.
 
         :param str name: name of the policy
         :param list() datacenters: A list of datacenters to filter the policy for. Default is an empty list for all datacenters.
         :param str description: Human readable description of the policy.
         :param str rules: A json serializable string for the ACL rules to define for the policy.
+        :param rtype: dict
+
         """
         return self._put_response_body(["policy"], {}, dict(
             model.ACLPolicy(name=name, datacenters=datacenters,
                             description=description, rules=rules)
         ))
 
-    def update_policy(self, id, datacenters=None, description=None, name=None, rules=None):
-        """ Update policy with id given.
+    def update_policy(self, id, name, datacenters=None, description=None, rules=None):
+        """Update policy with id given.
         :param str id: A UUID for the policy to update.
+        :param str name: name of the policy
         :param list() datacenters: A list of datacenters to filter the policy for. Default is an empty list for all datacenters.
         :param str description: Human readable description of the policy.
-        :param str name: name of the policy
         :param str rules: A json serializable string for the ACL rules to define for the policy.
+        :param rtype: dict
+
         """
         return self._put_response_body(["policy", id], {}, dict(
             model.ACLPolicy(name=name, datacenters=datacenters,
@@ -60,23 +70,29 @@ class ACL(base.Endpoint):
         ))
 
     def delete_policy(self, id):
-        """ Delete an existing policy with the given ID.
+        """Delete an existing policy with the given ID.
         :param str id: The ID of the policy.
+        :param rtype: dict
+
         """
 
         return self._delete(["policy", id])
 
     def list_roles(self):
-        """ List all ACL roles available in cluster
+        """List all ACL roles available in cluster
+        :param rtype: list
+
         """
         return self._get(["roles"])
 
     def create_role(self, name, description=None, policies=None, service_identities=None):
-        """ Create an ACL role from a list of policies and or service service_identities.
+        """Create an ACL role from a list of policies and or service service_identities.
         :param str name: The name of the ACL role. Must be unique alphanumeral and dashes and underscores.
         :param str description: The description of the ACL role.
         :param PolicyLinks policies: An array of PolicyLink.
         :param ServiceIdentities service_identities: An array of ServiceIdentity.
+        :param rtype: dict
+
         """
         return self._put_response_body(["role"], {}, dict(
             model.ACLPolicy(name=name, description=description,

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -8,8 +8,14 @@ import json
 from consulate.models import acl as model
 from consulate.api import base
 from consulate import exceptions
+# from typing import List, Dict, Union
 
 LOGGER = logging.getLogger(__name__)
+
+# ServiceIdentity = Dict[str, Union[str, List[str]]]
+# ServiceIdentities = List[ServiceIdentity]
+# PolicyLink = Dict[str, str]
+# PolicyLinks = List[PolicyLink]
 
 
 def __check_policylinks(policies):

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -48,6 +48,13 @@ class ACL(base.Endpoint):
 
         return self._get(["policy", id])
 
+    def delete_policy(self, id):
+        """ Delete an existing policy with the given ID.
+        :param str id: The ID of the policy.
+        """
+
+        return self._delete(["policy", id])
+
     # NOTE: Everything below here is deprecated post consul-1.4.0.
 
     def bootstrap(self):

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -3,12 +3,55 @@ Consul ACL Endpoint Access
 
 """
 import logging
+import json
 
 from consulate.models import acl as model
 from consulate.api import base
 from consulate import exceptions
 
 LOGGER = logging.getLogger(__name__)
+
+
+def __check_policylinks(policies):
+    """ Checks if policies is formatted correctly.
+    :param list policies: A list of PolicyLink.
+    :param rtype: bool
+    :raises: consulate.exceptions.ACLFormatError
+
+    """
+    for policy in policies:
+        if not ('ID' in policy or 'Name' in policy):
+            raise exceptions.ACLPolicyFormatError(str(policy))
+
+    return True
+
+
+def __check_service_identities(service_identities):
+    """ Checks if service_identities is formatted correctly.
+    :param list service_identities: A ServiceIdentity list
+    :param rtype: bool
+    :raises: consulate.exceptions.ACLFormatError
+
+    """
+    for service_identity in service_identities:
+        if 'ServiceName' not in service_identity:
+            raise exceptions.ACLPolicyFormatError(str(service_identity))
+
+    return True
+
+
+def __create_json_format(structures, check):
+    """Creates a json string from a structures provided check passes.
+    :param list structure: a PolicyLinks or ServiceIdentities.
+    :param function check: a function to check structure
+    :param rtype: str
+
+    """
+    formatted = None
+    if structures is not None and check(structures):
+        formatted = json.dumps(structures)
+
+    return formatted
 
 
 class ACL(base.Endpoint):

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -3,7 +3,6 @@ Consul ACL Endpoint Access
 
 """
 import logging
-import json
 
 from consulate.models import acl as model
 from consulate.api import base
@@ -18,48 +17,6 @@ LOGGER = logging.getLogger(__name__)
 # PolicyLinks = List[PolicyLink]
 # RoleLink = Dict[str, str]
 # RoleLinks = List[RoleLink]
-
-
-def __check_policylinks(policies):
-    """ Checks if policies is formatted correctly.
-    :param list policies: A list of PolicyLink.
-    :param rtype: bool
-    :raises: consulate.exceptions.ACLFormatError
-
-    """
-    for policy in policies:
-        if not ('ID' in policy or 'Name' in policy):
-            raise exceptions.ACLPolicyFormatError(str(policy))
-
-    return True
-
-
-def __check_service_identities(service_identities):
-    """ Checks if service_identities is formatted correctly.
-    :param list service_identities: A ServiceIdentity list
-    :param rtype: bool
-    :raises: consulate.exceptions.ACLFormatError
-
-    """
-    for service_identity in service_identities:
-        if 'ServiceName' not in service_identity:
-            raise exceptions.ACLPolicyFormatError(str(service_identity))
-
-    return True
-
-
-def __create_json_format(structures, check):
-    """Creates a json string from a structures provided check passes.
-    :param list structure: a PolicyLinks or ServiceIdentities.
-    :param function check: a function to check structure
-    :param rtype: str
-
-    """
-    formatted = None
-    if structures is not None and check(structures):
-        formatted = json.dumps(structures)
-
-    return formatted
 
 
 class ACL(base.Endpoint):
@@ -176,10 +133,6 @@ class ACL(base.Endpoint):
         :param rtype: dict
 
         """
-        policies = __create_json_format(policies, __check_policylinks)
-        service_identities = __create_json_format(service_identities,
-                                                  __check_service_identities)
-
         return self._put_response_body(
             ["role"], {},
             dict(
@@ -203,9 +156,6 @@ class ACL(base.Endpoint):
         :param rtype: dict
 
         """
-        policies = __create_json_format(policies, __check_policylinks)
-        service_identities = __create_json_format(service_identities,
-                                                  __check_service_identities)
         return self._put_response_body(
             ["role", id], {},
             dict(

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -135,7 +135,7 @@ class ACL(base.Endpoint):
     def delete_policy(self, id):
         """Delete an existing policy with the given ID.
         :param str id: The ID of the policy.
-        :param rtype: dict
+        :param rtype: bool
 
         """
         return self._delete(["policy", id])
@@ -211,6 +211,14 @@ class ACL(base.Endpoint):
                                 description=description,
                                 policies=policies,
                                 service_identities=service_identities)))
+
+    def delete_role(self, id):
+        """Delete an existing role with the given ID.
+        :param str id: The ID of the role.
+        :param rtype: bool
+
+        """
+        return self._delete(["policy", id])
 
     # NOTE: Everything below here is deprecated post consul-1.4.0.
 

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -135,10 +135,10 @@ class ACL(base.Endpoint):
         return self._put_response_body(
             ["role"], {},
             dict(
-                model.ACLPolicy(name=name,
-                                description=description,
-                                policies=policies,
-                                service_identities=service_identities)))
+                model.ACLRole(name=name,
+                              description=description,
+                              policies=policies,
+                              service_identities=service_identities)))
 
     def update_role(self,
                     id,
@@ -159,10 +159,10 @@ class ACL(base.Endpoint):
         return self._put_response_body(
             ["role", id], {},
             dict(
-                model.ACLPolicy(name=name,
-                                description=description,
-                                policies=policies,
-                                service_identities=service_identities)))
+                model.ACLRole(name=name,
+                              description=description,
+                              policies=policies,
+                              service_identities=service_identities)))
 
     def delete_role(self, id):
         """Delete an existing role with the given ID.

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -24,13 +24,6 @@ class ACL(base.Endpoint):
     tokens.
 
     """
-    def read_self_token(self):
-        """Retrieve the currently used token.
-        :param rtype: dict
-
-        """
-        return self._get(["token", "self"])
-
     def list_policies(self):
         """List all ACL policies available in cluster.
         :param rtype: list
@@ -172,6 +165,28 @@ class ACL(base.Endpoint):
         """
         return self._delete(["policy", id])
 
+    def list_tokens(self):
+        """List all ACL tokens available in cluster.
+        :param rtype: list
+
+        """
+        return self._get(["tokens"])
+
+    def read_token(self, accessor_id):
+        """Read an existing token with the given ID.
+        :param str id: The ID of the role.
+        :param rtype: dict
+
+        """
+        return self._get(["token", accessor_id])
+
+    def read_self_token(self):
+        """Retrieve the currently used token.
+        :param rtype: dict
+
+        """
+        return self._get(["token", "self"])
+
     def create_token(self,
                      accessor_id=None,
                      description=None,
@@ -198,7 +213,17 @@ class ACL(base.Endpoint):
         :param rtype: dict
 
         """
-        pass
+        return self._put_response_body(
+            ["token"], {},
+            dict(
+                model.ACLToken(accessor_id=accessor_id,
+                               description=description,
+                               expiration_time=expiration_time,
+                               expiration_ttl=expiration_ttl,
+                               local=local,
+                               policies=policies,
+                               roles=roles,
+                               service_identities=service_identities)))
 
     # NOTE: Everything below here is deprecated post consul-1.4.0.
 

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -16,6 +16,8 @@ LOGGER = logging.getLogger(__name__)
 # ServiceIdentities = List[ServiceIdentity]
 # PolicyLink = Dict[str, str]
 # PolicyLinks = List[PolicyLink]
+# RoleLink = Dict[str, str]
+# RoleLinks = List[RoleLink]
 
 
 def __check_policylinks(policies):
@@ -219,6 +221,34 @@ class ACL(base.Endpoint):
 
         """
         return self._delete(["policy", id])
+
+    def create_token(self,
+                     accessor_id=None,
+                     description=None,
+                     expiration_time=None,
+                     expiration_ttl=None,
+                     local=False,
+                     policies=None,
+                     roles=None,
+                     secret_id=None,
+                     service_identities=None):
+        """Create a token from the roles, policies, and service identities
+        provided.
+        :param str accessor_id: A UUID for accessing the token.
+        :param str description: A human-readable description of the token.
+        :param str expiration_time: The amount of time till the token expires.
+        :param str expiration_ttl: Sets expiration_time to creation time +
+        expiration_ttl value.
+        :param bool local: Whether the token is only locally available in the
+        current datacenter or to all datacenters defined.
+        :param PolicyLinks policies: A PolicyLink array.
+        :param RoleLinks roles: A RoleLink array.
+        :param str secret_id: A UUID for making requests to consul.
+        :param ServiceIdentities service_identities: A ServiceIdentity array.
+        :param rtype: dict
+
+        """
+        pass
 
     # NOTE: Everything below here is deprecated post consul-1.4.0.
 

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -235,6 +235,7 @@ class ACL(base.Endpoint):
                                local=local,
                                policies=policies,
                                roles=roles,
+                               secret_id=secret_id,
                                service_identities=service_identities)))
 
     def update_token(self,
@@ -274,6 +275,7 @@ class ACL(base.Endpoint):
                                local=local,
                                policies=policies,
                                roles=roles,
+                               secret_id=secret_id,
                                service_identities=service_identities)))
 
     def clone_token(self, accessor_id, description=None):

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -23,7 +23,7 @@ class ACL(base.Endpoint):
         return self._get(["token", "self"])
 
     def list_policies(self):
-        """ List all policies available in cluster
+        """ List all ACL policies available in cluster
         """
         return self._get(["policies"])
 
@@ -65,6 +65,23 @@ class ACL(base.Endpoint):
         """
 
         return self._delete(["policy", id])
+
+    def list_roles(self):
+        """ List all ACL roles available in cluster
+        """
+        return self._get(["roles"])
+
+    def create_role(self, name, description=None, policies=None, service_identities=None):
+        """ Create an ACL role from a list of policies and or service service_identities.
+        :param str name: The name of the ACL role. Must be unique alphanumeral and dashes and underscores.
+        :param str description: The description of the ACL role.
+        :param PolicyLinks policies: An array of PolicyLink.
+        :param ServiceIdentities service_identities: An array of ServiceIdentity.
+        """
+        return self._put_response_body(["role"], {}, dict(
+            model.ACLPolicy(name=name, description=description,
+                            policies=policies, service_identities=service_identities)
+        ))
 
     # NOTE: Everything below here is deprecated post consul-1.4.0.
 

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -26,6 +26,7 @@ class ACL(base.Endpoint):
     """
     def list_policies(self):
         """List all ACL policies available in cluster.
+
         :param rtype: list
 
         """
@@ -33,6 +34,7 @@ class ACL(base.Endpoint):
 
     def read_policy(self, id):
         """Read an existing policy with the given ID.
+
         :param str id: The ID of the policy.
         :param rtype: dict
 
@@ -68,6 +70,7 @@ class ACL(base.Endpoint):
                       description=None,
                       rules=None):
         """Update policy with id given.
+
         :param str id: A UUID for the policy to update.
         :param str name: name of the policy
         :param list() datacenters: A list of datacenters to filter on policy.
@@ -86,6 +89,7 @@ class ACL(base.Endpoint):
 
     def delete_policy(self, id):
         """Delete an existing policy with the given ID.
+
         :param str id: The ID of the policy.
         :param rtype: bool
 
@@ -101,6 +105,7 @@ class ACL(base.Endpoint):
 
     def read_role(self, id=None, name=None):
         """Read an existing role with the given ID or Name.
+
         :param str id: The ID of the role.
         :param str name: The name of the role.
         :param rtype: dict
@@ -119,6 +124,7 @@ class ACL(base.Endpoint):
                     policies=None,
                     service_identities=None):
         """Create an ACL role from a list of policies or service identities.
+
         :param str name: The name of the ACL role. Must be unique.
         :param str description: The description of the ACL role.
         :param PolicyLinks policies: An array of PolicyLink.
@@ -141,6 +147,7 @@ class ACL(base.Endpoint):
                     policies=None,
                     service_identities=None):
         """Update role with id given.
+
         :param str id: A UUID for the policy to update.
         :param str name: name of the policy
         :param list() datacenters: A list of datacenters to filter on policy.
@@ -159,6 +166,7 @@ class ACL(base.Endpoint):
 
     def delete_role(self, id):
         """Delete an existing role with the given ID.
+
         :param str id: The ID of the role.
         :param rtype: bool
 
@@ -167,6 +175,7 @@ class ACL(base.Endpoint):
 
     def list_tokens(self):
         """List all ACL tokens available in cluster.
+
         :param rtype: list
 
         """
@@ -174,6 +183,7 @@ class ACL(base.Endpoint):
 
     def read_token(self, accessor_id):
         """Read an existing token with the given ID.
+
         :param str id: The ID of the role.
         :param rtype: dict
 
@@ -182,6 +192,7 @@ class ACL(base.Endpoint):
 
     def read_self_token(self):
         """Retrieve the currently used token.
+
         :param rtype: dict
 
         """
@@ -199,6 +210,7 @@ class ACL(base.Endpoint):
                      service_identities=None):
         """Create a token from the roles, policies, and service identities
         provided.
+
         :param str accessor_id: A UUID for accessing the token.
         :param str description: A human-readable description of the token.
         :param str expiration_time: The amount of time till the token expires.
@@ -224,6 +236,15 @@ class ACL(base.Endpoint):
                                policies=policies,
                                roles=roles,
                                service_identities=service_identities)))
+
+    def delete_token(self, accessor_id):
+        """Delete an existing token with the given AcccessorID.
+
+        :param str id: The AccessorID of the token.
+        :param rtype: bool
+
+        """
+        return self._delete(["token", accessor_id])
 
     # NOTE: Everything below here is deprecated post consul-1.4.0.
 

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -138,7 +138,6 @@ class ACL(base.Endpoint):
         :param rtype: dict
 
         """
-
         return self._delete(["policy", id])
 
     def list_roles(self):
@@ -147,6 +146,20 @@ class ACL(base.Endpoint):
 
         """
         return self._get(["roles"])
+
+    def read_role(self, id=None, name=None):
+        """Read an existing role with the given ID or Name.
+        :param str id: The ID of the role.
+        :param str name: The name of the role.
+        :param rtype: dict
+
+        """
+        if id is not None:
+            return self._get(["role", id])
+        elif name is not None:
+            return self._get(["role", "name", name])
+        else:
+            raise exceptions.NotFound("Either id or name must be specified")
 
     def create_role(self,
                     name,
@@ -161,8 +174,38 @@ class ACL(base.Endpoint):
         :param rtype: dict
 
         """
+        policies = __create_json_format(policies, __check_policylinks)
+        service_identities = __create_json_format(service_identities,
+                                                  __check_service_identities)
+
         return self._put_response_body(
             ["role"], {},
+            dict(
+                model.ACLPolicy(name=name,
+                                description=description,
+                                policies=policies,
+                                service_identities=service_identities)))
+
+    def update_role(self,
+                    id,
+                    name,
+                    description=None,
+                    policies=None,
+                    service_identities=None):
+        """Update role with id given.
+        :param str id: A UUID for the policy to update.
+        :param str name: name of the policy
+        :param list() datacenters: A list of datacenters to filter on policy.
+        :param str description: Human readable description of the policy.
+        :param str rules: A json serializable string for ACL rules.
+        :param rtype: dict
+
+        """
+        policies = __create_json_format(policies, __check_policylinks)
+        service_identities = __create_json_format(service_identities,
+                                                  __check_service_identities)
+        return self._put_response_body(
+            ["role", id], {},
             dict(
                 model.ACLPolicy(name=name,
                                 description=description,

--- a/consulate/api/acl.py
+++ b/consulate/api/acl.py
@@ -237,6 +237,45 @@ class ACL(base.Endpoint):
                                roles=roles,
                                service_identities=service_identities)))
 
+    def update_token(self,
+                     accessor_id,
+                     description=None,
+                     expiration_time=None,
+                     expiration_ttl=None,
+                     local=False,
+                     policies=None,
+                     roles=None,
+                     secret_id=None,
+                     service_identities=None):
+        """Create a token from the roles, policies, and service identities
+        provided.
+
+        :param str accessor_id: A UUID for accessing the token.
+        :param str description: A human-readable description of the token.
+        :param str expiration_time: The amount of time till the token expires.
+        :param str expiration_ttl: Sets expiration_time to creation time +
+        expiration_ttl value.
+        :param bool local: Whether the token is only locally available in the
+        current datacenter or to all datacenters defined.
+        :param PolicyLinks policies: A PolicyLink array.
+        :param RoleLinks roles: A RoleLink array.
+        :param str secret_id: A UUID for making requests to consul.
+        :param ServiceIdentities service_identities: A ServiceIdentity array.
+        :param rtype: dict
+
+        """
+        return self._put_response_body(
+            ["token", accessor_id], {},
+            dict(
+                model.ACLToken(accessor_id=accessor_id,
+                               description=description,
+                               expiration_time=expiration_time,
+                               expiration_ttl=expiration_ttl,
+                               local=local,
+                               policies=policies,
+                               roles=roles,
+                               service_identities=service_identities)))
+
     def delete_token(self, accessor_id):
         """Delete an existing token with the given AcccessorID.
 

--- a/consulate/api/base.py
+++ b/consulate/api/base.py
@@ -75,13 +75,13 @@ class Endpoint(object):
         """Perform a DELETE request
 
         :param list params: List of path parts
-        :rtype: dict or list or None
+        :rtype: bool
 
         """
         response = self._adapter.delete(self._build_uri(params))
         if utils.response_ok(response, raise_on_404):
             return response.body
-        return []
+        return False
 
     def _get_list(self, params, query_params=None):
         """Return a list queried from Consul

--- a/consulate/api/base.py
+++ b/consulate/api/base.py
@@ -67,6 +67,20 @@ class Endpoint(object):
             return response.body
         return []
 
+    def _delete(self, params, raise_on_404=False,
+                ):
+        """Perform a DELETE request
+
+        :param list params: List of path parts
+        :rtype: dict or list or None
+
+        """
+        response = self._adapter.delete(
+            self._build_uri(params))
+        if utils.response_ok(response, raise_on_404):
+            return response.body
+        return []
+
     def _get_list(self, params, query_params=None):
         """Return a list queried from Consul
 

--- a/consulate/api/base.py
+++ b/consulate/api/base.py
@@ -61,22 +61,24 @@ class Endpoint(object):
         :rtype: dict or list or None
 
         """
-        response = self._adapter.get(
-            self._build_uri(params, query_params), timeout=timeout)
+        response = self._adapter.get(self._build_uri(params, query_params),
+                                     timeout=timeout)
         if utils.response_ok(response, raise_on_404):
             return response.body
         return []
 
-    def _delete(self, params, raise_on_404=False,
-                ):
+    def _delete(
+            self,
+            params,
+            raise_on_404=False,
+    ):
         """Perform a DELETE request
 
         :param list params: List of path parts
         :rtype: dict or list or None
 
         """
-        response = self._adapter.delete(
-            self._build_uri(params))
+        response = self._adapter.delete(self._build_uri(params))
         if utils.response_ok(response, raise_on_404):
             return response.body
         return []
@@ -119,8 +121,8 @@ class Endpoint(object):
             self._adapter.put(self._build_uri(url_parts, query), payload))
 
     def _put_response_body(self, url_parts, query=None, payload=None):
-        response = self._adapter.put(
-            self._build_uri(url_parts, query), data=payload)
+        response = self._adapter.put(self._build_uri(url_parts, query),
+                                     data=payload)
         if utils.response_ok(response):
             return response.body
 

--- a/consulate/exceptions.py
+++ b/consulate/exceptions.py
@@ -24,6 +24,13 @@ class ACLDisabled(ConsulateException):
     """Raised when ACL related calls are made while ACLs are disabled"""
 
 
+class ACLFormatError(ConsulateException):
+    """Raised when PolicyLinks is missing 'ID' and 'Name' in a PolicyLink or
+    when ServiceIdentities is missing 'ServiceName' field in a ServiceIdentity.
+
+    """
+
+
 class Forbidden(ConsulateException):
     """Raised when ACLs are enabled and the token does not validate"""
 

--- a/consulate/models/acl.py
+++ b/consulate/models/acl.py
@@ -8,26 +8,22 @@ from consulate.models import base
 def _validate_link_array(value, model):
     """ Validate the policies or roles links are formatted correctly.
 
-    :param list(dict()) value: An array of PolicyLink or RoleLink.
-    :param rtype: bool
-    :param consulate.models.agent.Check model: The model instance.
+    :param list value: An array of PolicyLink or RoleLink.
     :param rtype: bool
 
     """
-    return all(['ID' in link or 'Name' in link
-                for link in value]) and not model.args
+    return all(['ID' in link or 'Name' in link for link in value])
 
 
 def _validate_service_identities(value, model):
     """ Validate service_identities is formatted correctly.
 
-    :param list(dict()) value: A ServiceIdentity list
+    :param ServiceIdentities value: A ServiceIdentity list
     :param rtype: bool
 
     """
     return all(
-        ['ServiceName' in service_identity
-         for service_identity in value]) and not model.args
+        ['ServiceName' in service_identity for service_identity in value])
 
 
 class ACLPolicy(base.Model):

--- a/consulate/models/acl.py
+++ b/consulate/models/acl.py
@@ -7,6 +7,7 @@ from consulate.models import base
 
 def _validate_link_array(value, model):
     """ Validate the policies or roles links are formatted correctly.
+
     :param list(dict()) value: An array of PolicyLink or RoleLink.
     :param rtype: bool
     :param consulate.models.agent.Check model: The model instance.
@@ -19,6 +20,7 @@ def _validate_link_array(value, model):
 
 def _validate_service_identities(value, model):
     """ Validate service_identities is formatted correctly.
+
     :param list(dict()) value: A ServiceIdentity list
     :param rtype: bool
 

--- a/consulate/models/acl.py
+++ b/consulate/models/acl.py
@@ -6,8 +6,7 @@ from consulate.models import base
 
 
 class ACLPolicy(base.Model):
-    """Defins the model used fur an ACL policy.
-    """
+    """Defines the model used fur an ACL policy."""
     __slots__ = ['datacenters', 'description', 'id', 'name', 'rules']
 
     __attributes__ = {
@@ -32,6 +31,31 @@ class ACLPolicy(base.Model):
         'rules': {
             'key': 'Rules',
             'type': str,
+        }
+    }
+
+
+class ACLRole(base.Model):
+    """Defines the model used fur an ACL role."""
+    __slots__ = ['description', 'name', 'policies', 'service_identities']
+
+    __attributes__ = {
+        'description': {
+            'key': 'Description',
+            'type': str,
+        },
+        'name': {
+            'key': 'Name',
+            'type': str,
+            'required': True,
+        },
+        'policies': {
+            'key': 'Policies',
+            'type': list,
+        },
+        "service_identities": {
+            'key': 'ServiceIdentities',
+            'type': list,
         }
     }
 

--- a/consulate/models/acl.py
+++ b/consulate/models/acl.py
@@ -5,6 +5,37 @@ import uuid
 from consulate.models import base
 
 
+class ACLPolicy(base.Model):
+    """Defins the model used fur an ACL policy.
+    """
+    __slots__ = ['datacenters', 'description', 'id', 'name', 'rules']
+
+    __attributes__ = {
+        'datacenters': {
+            'key': 'Datacenters',
+            'type': list,
+        },
+        'description': {
+            'key': 'Description',
+            'type': str,
+        },
+        'id': {
+            'key': 'ID',
+            'type': uuid.UUID,
+            'cast_from': str,
+            'cast_to': str,
+        },
+        'name': {
+            'key': 'Name',
+            'type': str,
+        },
+        'rules': {
+            'key': 'Rules',
+            'type': str,
+        }
+    }
+
+
 class ACL(base.Model):
     """Defines the model used for an individual ACL token."""
     __slots__ = ['id', 'name', 'type', 'rules']

--- a/consulate/models/acl.py
+++ b/consulate/models/acl.py
@@ -5,6 +5,29 @@ import uuid
 from consulate.models import base
 
 
+def _validate_link_array(value, model):
+    """ Validate the policies or roles links are formatted correctly.
+    :param list(dict()) value: An array of PolicyLink or RoleLink.
+    :param rtype: bool
+    :param consulate.models.agent.Check model: The model instance.
+    :param rtype: bool
+
+    """
+    return all(['ID' in link or 'Name' in link
+                for link in value]) and not model.args
+
+
+def _validate_service_identities(value, model):
+    """ Validate service_identities is formatted correctly.
+    :param list(dict()) value: A ServiceIdentity list
+    :param rtype: bool
+
+    """
+    return all(
+        ['ServiceName' in service_identity
+         for service_identity in value]) and not model.args
+
+
 class ACLPolicy(base.Model):
     """Defines the model used for an ACL policy."""
     __slots__ = ['datacenters', 'description', 'id', 'name', 'rules']
@@ -52,10 +75,12 @@ class ACLRole(base.Model):
         'policies': {
             'key': 'Policies',
             'type': list,
+            'validator': _validate_link_array,
         },
         "service_identities": {
             'key': 'ServiceIdentities',
             'type': list,
+            'validator': _validate_service_identities,
         }
     }
 
@@ -66,7 +91,52 @@ class ACLToken(base.Model):
         'accessor_id', 'description', 'expiration_time', 'expiration_ttl',
         'local', 'policies', 'roles', 'secret_id', 'service_identities'
     ]
-    pass
+
+    __attributes__ = {
+        'accessor_id': {
+            'key': 'AccessorID',
+            'type': uuid.UUID,
+            'cast_from': str,
+            'cast_to': str,
+        },
+        'description': {
+            'key': 'Description',
+            'type': str,
+        },
+        'expiration_time': {
+            'key': 'ExpirationTime',
+            'type': str,
+        },
+        'expiration_ttl': {
+            'key': 'ExpirationTTL',
+            'type': str,
+        },
+        'local': {
+            'key': 'Local',
+            'type': bool,
+        },
+        'policies': {
+            'key': 'Policies',
+            'type': list,
+            'validator': _validate_link_array,
+        },
+        'roles': {
+            'key': 'Roles',
+            'type': list,
+            'validator': _validate_link_array,
+        },
+        'secret_id': {
+            'key': 'SecretID',
+            'type': uuid.UUID,
+            'cast_from': str,
+            'cast_to': str,
+        },
+        "service_identities": {
+            'key': 'ServiceIdentities',
+            'type': list,
+            'validator': _validate_service_identities,
+        }
+    }
 
 
 # NOTE: Everything below here is deprecated post consul-1.4.0.

--- a/consulate/models/acl.py
+++ b/consulate/models/acl.py
@@ -6,7 +6,7 @@ from consulate.models import base
 
 
 class ACLPolicy(base.Model):
-    """Defines the model used fur an ACL policy."""
+    """Defines the model used for an ACL policy."""
     __slots__ = ['datacenters', 'description', 'id', 'name', 'rules']
 
     __attributes__ = {
@@ -36,7 +36,7 @@ class ACLPolicy(base.Model):
 
 
 class ACLRole(base.Model):
-    """Defines the model used fur an ACL role."""
+    """Defines the model used for an ACL role."""
     __slots__ = ['description', 'name', 'policies', 'service_identities']
 
     __attributes__ = {
@@ -58,6 +58,18 @@ class ACLRole(base.Model):
             'type': list,
         }
     }
+
+
+class ACLToken(base.Model):
+    """Defines the model used for an ACL token."""
+    __slots__ = [
+        'accessor_id', 'description', 'expiration_time', 'expiration_ttl',
+        'local', 'policies', 'roles', 'secret_id', 'service_identities'
+    ]
+    pass
+
+
+# NOTE: Everything below here is deprecated post consul-1.4.0.
 
 
 class ACL(base.Model):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 consul:
-  image: consul:1.0.6
+  image: consul:1.6.0
   ports:
     - 8500
   volumes:

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 import setuptools
 
 setuptools.setup(
-    name='consulate',
-    version='1.0.0',
+    name='abaez.consulate',
+    version='1.1.0',
     description='A Client library and command line application for the Consul',
     maintainer='Gavin M. Roy',
     maintainer_email='gavinr@aweber.com',

--- a/testing/consul.json
+++ b/testing/consul.json
@@ -1,9 +1,16 @@
 {
-  "acl_datacenter": "test",
-  "acl_master_token": "9ae5fe1a-6b38-47e5-a0e7-f06b8b2fa645",
-  "bootstrap": true,
+  "acl": {
+    "enabled": true,
+    "enable_key_list_policy": true,
+    "tokens": {
+      "master": "9ae5fe1a-6b38-47e5-a0e7-f06b8b2fa645"
+    }
+  },
+  "bootstrap_expect": 1,
   "data_dir": "/tmp/consul",
   "datacenter": "test",
   "server": true,
+  "bind_addr": "{{ GetPrivateIP }}",
+  "client_addr": "0.0.0.0",
   "enable_script_checks": true
 }

--- a/tests/acl_tests.py
+++ b/tests/acl_tests.py
@@ -206,7 +206,7 @@ class TestCase(base.TestCase):
     def test_create_token(self):
         secret_id = self.uuidv4()
         accessor_id = self.uuidv4()
-        result = self.consul.acl.create_create_token(
+        result = self.consul.acl.create_token(
             accessor_id=accessor_id,
             secret_id=secret_id,
             roles=ROLELINKS_SAMPLE,
@@ -214,3 +214,27 @@ class TestCase(base.TestCase):
             service_identities=SERVICE_IDENTITIES_SAMPLE)
         self.assertEqual(result['AccessorID'], accessor_id)
         self.assertEqual(result['SecretID'], secret_id)
+
+    def test_create_and_read_token(self):
+        secret_id = self.uuidv4()
+        accessor_id = self.uuidv4()
+        value = self.consul.acl.create_token(
+            accessor_id=accessor_id,
+            secret_id=secret_id,
+            roles=ROLELINKS_SAMPLE,
+            policies=POLICYLINKS_SAMPLE,
+            service_identities=SERVICE_IDENTITIES_SAMPLE)
+        result = self.consul.acl.read_token(value["AccessorID"])
+        self.assertEqual(result['AccessorID'], accessor_id)
+
+    def test_create_and_delete_token(self):
+        secret_id = self.uuidv4()
+        accessor_id = self.uuidv4()
+        value = self.consul.acl.create_token(
+            accessor_id=accessor_id,
+            secret_id=secret_id,
+            roles=ROLELINKS_SAMPLE,
+            policies=POLICYLINKS_SAMPLE,
+            service_identities=SERVICE_IDENTITIES_SAMPLE)
+        result = self.consul.acl.delete_token(value["AccessorID"])
+        self.assertTrue(result)

--- a/tests/acl_tests.py
+++ b/tests/acl_tests.py
@@ -270,6 +270,20 @@ class TestCase(base.TestCase):
             value["AccessorID"], policies=POLICYLINKS_UPDATE_SAMPLE)
         self.assertGreater(result["ModifyIndex"], result["CreateIndex"])
 
+    def test_create_and_clone_token(self):
+        secret_id = self.uuidv4()
+        accessor_id = self.uuidv4()
+        clone_description = "clone token of " + accessor_id
+        value = self.consul.acl.create_token(
+            accessor_id=accessor_id,
+            secret_id=secret_id,
+            roles=ROLELINKS_SAMPLE,
+            policies=POLICYLINKS_SAMPLE,
+            service_identities=SERVICE_IDENTITIES_SAMPLE)
+        result = self.consul.acl.clone_token(value["AccessorID"],
+                                             description="clone")
+        self.assertEqual(result["Description"], clone_description)
+
     def test_create_and_delete_token(self):
         secret_id = self.uuidv4()
         accessor_id = self.uuidv4()

--- a/tests/acl_tests.py
+++ b/tests/acl_tests.py
@@ -37,17 +37,17 @@ key "foo/" {
 """
 
 POLICYLINKS_SAMPLE = [
-    dict(ID="783beef3-783f-f41f-7422-7087dc272765"),
+    dict(Name="policylink_sample"),
 ]
 
 POLICYLINKS_UPDATE_SAMPLE = [
-    dict(ID="783beef3-783f-f41f-7422-7087dc272765"),
-    dict(Name="some_policy_name")
+    dict(Name="policylink_sample"),
+    dict(Name="policylink_update_sample")
 ]
 
 SERVICE_IDENTITIES_SAMPLE = [dict(ServiceName="db", Datacenters=["dc1"])]
 
-ROLELINKS_SAMPLE = [dict(Name="some_role_name")]
+ROLELINKS_SAMPLE = [dict(Name="role_sample")]
 
 
 class TestCase(base.TestCase):

--- a/tests/acl_tests.py
+++ b/tests/acl_tests.py
@@ -28,6 +28,12 @@ key "foo/" {
 }
 """
 
+POLICYLINKS_SAMPLE = [
+    dict(ID="783beef3-783f-f41f-7422-7087dc272765"),
+]
+
+SERVICE_IDENTITIES_SAMPLE = [dict(ServiceName="db", Datacenters=["dc1"])]
+
 
 class TestCase(base.TestCase):
     @staticmethod
@@ -164,3 +170,33 @@ class TestCase(base.TestCase):
         with httmock.HTTMock(base.raise_oserror):
             with self.assertRaises(exceptions.RequestError):
                 self.consul.acl.list_policies()
+
+    def test_create_role(self):
+        result = self.consul.acl.create_create_role(
+            "unittest_create_role",
+            policies=POLICYLINKS_SAMPLE,
+            service_identities=SERVICE_IDENTITIES_SAMPLE)
+        self.assertEqual(result['Policies'][0]['ID'],
+                         POLICYLINKS_SAMPLE['Policies'][0]['ID'])
+
+    def test_create_and_read_role(self):
+        value = self.consul.acl.create_role(
+            "unittest_read_role",
+            policies=POLICYLINKS_SAMPLE,
+            service_identities=SERVICE_IDENTITIES_SAMPLE)
+        result = self.consul.acl.read_role(value["ID"])
+        self.assertEqual(result['Policies'][0]['ID'],
+                         POLICYLINKS_SAMPLE[0]["ID"])
+
+    def test_create_and_delete_role(self):
+        value = self.consul.acl.create_role(
+            "unittest_delete_role",
+            policies=POLICYLINKS_SAMPLE,
+            service_identities=SERVICE_IDENTITIES_SAMPLE)
+        result = self.consul.acl.delete_role(value["ID"])
+        self.assertTrue(result)
+
+    def test_list_roles_exception(self):
+        with httmock.HTTMock(base.raise_oserror):
+            with self.assertRaises(exceptions.RequestError):
+                self.consul.acl.list_roles()

--- a/tests/acl_tests.py
+++ b/tests/acl_tests.py
@@ -180,7 +180,7 @@ class TestCase(base.TestCase):
                                               rules=ACL_NEW_RULES)
         result = self.consul.acl.update_policy(value["ID"],
                                                value["Name"],
-                                               policy=ACL_NEW_UPDATE_RULES)
+                                               rules=ACL_NEW_UPDATE_RULES)
         self.assertGreater(result["ModifyIndex"], result["CreateIndex"])
 
     def test_create_and_delete_policy(self):
@@ -195,12 +195,11 @@ class TestCase(base.TestCase):
                 self.consul.acl.list_policies()
 
     def test_create_role(self):
-        result = self.consul.acl.create_create_role(
+        result = self.consul.acl.create_role(
             "unittest_create_role",
             policies=POLICYLINKS_SAMPLE,
             service_identities=SERVICE_IDENTITIES_SAMPLE)
-        self.assertEqual(result['Policies'][0]['ID'],
-                         POLICYLINKS_SAMPLE['Policies'][0]['ID'])
+        self.assertEqual(result[0]['ID'], POLICYLINKS_SAMPLE[0]['ID'])
 
     def test_create_and_read_role(self):
         value = self.consul.acl.create_role(
@@ -217,7 +216,9 @@ class TestCase(base.TestCase):
             policies=POLICYLINKS_SAMPLE,
             service_identities=SERVICE_IDENTITIES_SAMPLE)
         result = self.consul.acl.update_role(
-            value["ID"], policies=POLICYLINKS_UPDATE_SAMPLE)
+            value["ID"],
+            "unittest_read_role",
+            policies=POLICYLINKS_UPDATE_SAMPLE)
         self.assertGreater(result["ModifyIndex"], result["CreateIndex"])
 
     def test_create_and_delete_role(self):

--- a/tests/acl_tests.py
+++ b/tests/acl_tests.py
@@ -30,13 +30,11 @@ key "foo/" {
 
 
 class TestCase(base.TestCase):
-
     @staticmethod
     def uuidv4():
         return str(uuid.uuid4())
 
     def test_bootstrap_request_exception(self):
-
         @httmock.all_requests
         def response_content(_url_unused, _request):
             raise OSError
@@ -50,8 +48,8 @@ class TestCase(base.TestCase):
 
         @httmock.all_requests
         def response_content(_url_unused, request):
-            return httmock.response(
-                200, json.dumps({'ID': expectation}), {}, None, 0, request)
+            return httmock.response(200, json.dumps({'ID': expectation}), {},
+                                    None, 0, request)
 
         with httmock.HTTMock(response_content):
             result = self.consul.acl.bootstrap()
@@ -133,8 +131,9 @@ class TestCase(base.TestCase):
         self.assertIn(acl_id, [r.get('ID') for r in data])
 
     def test_update_with_rules(self):
-        acl_id = self.consul.acl.update(
-            self.uuidv4(), name='test', rules=ACL_OLD_RULES)
+        acl_id = self.consul.acl.update(self.uuidv4(),
+                                        name='test',
+                                        rules=ACL_OLD_RULES)
         value = self.consul.acl.info(acl_id)
         self.assertEqual(value['Rules'], ACL_OLD_RULES)
 
@@ -145,19 +144,19 @@ class TestCase(base.TestCase):
     # NOTE: Everything above here is deprecated post consul-1.4.0
 
     def test_create_policy(self):
-        result = self.consul.acl.create_policy(
-            "unittest_create_policy", rules=ACL_NEW_RULES)
+        result = self.consul.acl.create_policy("unittest_create_policy",
+                                               rules=ACL_NEW_RULES)
         self.assertEqual(result['Rules'], ACL_NEW_RULES)
 
     def test_create_and_read_policy(self):
-        value = self.consul.acl.create_policy(
-            "unittest_read_policy", rules=ACL_NEW_RULES)
+        value = self.consul.acl.create_policy("unittest_read_policy",
+                                              rules=ACL_NEW_RULES)
         result = self.consul.acl.read_policy(value["ID"])
         self.assertEqual(result['Rules'], ACL_NEW_RULES)
 
     def test_create_and_delete_policy(self):
-        value = self.consul.acl.create_policy(
-            "unittest_delete_policy", rules=ACL_NEW_RULES)
+        value = self.consul.acl.create_policy("unittest_delete_policy",
+                                              rules=ACL_NEW_RULES)
         result = self.consul.acl.delete_policy(value["ID"])
         self.assertTrue(result)
 

--- a/tests/acl_tests.py
+++ b/tests/acl_tests.py
@@ -34,6 +34,8 @@ POLICYLINKS_SAMPLE = [
 
 SERVICE_IDENTITIES_SAMPLE = [dict(ServiceName="db", Datacenters=["dc1"])]
 
+ROLELINKS_SAMPLE = [dict(Name="some_role_name")]
+
 
 class TestCase(base.TestCase):
     @staticmethod
@@ -200,3 +202,15 @@ class TestCase(base.TestCase):
         with httmock.HTTMock(base.raise_oserror):
             with self.assertRaises(exceptions.RequestError):
                 self.consul.acl.list_roles()
+
+    def test_create_token(self):
+        secret_id = self.uuidv4()
+        accessor_id = self.uuidv4()
+        result = self.consul.acl.create_create_token(
+            accessor_id=accessor_id,
+            secret_id=secret_id,
+            roles=ROLELINKS_SAMPLE,
+            policies=POLICYLINKS_SAMPLE,
+            service_identities=SERVICE_IDENTITIES_SAMPLE)
+        self.assertEqual(result['AccessorID'], accessor_id)
+        self.assertEqual(result['SecretID'], secret_id)

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -35,7 +35,7 @@ class ConsulTests(unittest.TestCase):
         self.host = '127.0.0.1'
         self.port = 8500
         self.dc = CONSUL_CONFIG['datacenter']
-        self.token = CONSUL_CONFIG['acl_master_token']
+        self.token = CONSUL_CONFIG['acl']['tokens']['master']
 
         self.acl = acl
         self.adapter = adapter
@@ -98,7 +98,7 @@ class ConsulTests(unittest.TestCase):
     def test_coordinate_initialization(self):
         self.assertTrue(
             self.coordinate.called_once_with(self.base_uri, self.adapter, self.dc,
-                                         self.token))
+                                             self.token))
 
     def test_session_initialization(self):
         self.assertTrue(

--- a/tests/base.py
+++ b/tests/base.py
@@ -33,7 +33,7 @@ class TestCase(unittest.TestCase):
         self.consul = consulate.Consul(
             host=os.environ['CONSUL_HOST'],
             port=os.environ['CONSUL_PORT'],
-            token=CONSUL_CONFIG['acl_master_token'])
+            token=CONSUL_CONFIG['acl']['tokens']['master'])
         self.forbidden_consul = consulate.Consul(
             host=os.environ['CONSUL_HOST'],
             port=os.environ['CONSUL_PORT'],
@@ -53,7 +53,7 @@ class TestCase(unittest.TestCase):
             self.consul.agent.service.deregister(services[name]['ID'])
 
         for acl in self.consul.acl.list():
-            if acl['ID'] == CONSUL_CONFIG['acl_master_token']:
+            if acl['ID'] == CONSUL_CONFIG['acl']['tokens']['master']:
                 continue
             try:
                 uuid.UUID(acl['ID'])

--- a/tests/base.py
+++ b/tests/base.py
@@ -52,11 +52,11 @@ class TestCase(unittest.TestCase):
         for name in services:
             self.consul.agent.service.deregister(services[name]['ID'])
 
-        for acl in self.consul.acl.list():
-            if acl['ID'] == CONSUL_CONFIG['acl']['tokens']['master']:
+        for acl in self.consul.acl.list_tokens():
+            if acl['AccessorID'] == CONSUL_CONFIG['acl']['tokens']['master']:
                 continue
             try:
-                uuid.UUID(acl['ID'])
-                self.consul.acl.destroy(acl['ID'])
+                uuid.UUID(acl['AccessorID'])
+                self.consul.acl.delete_token(acl['AccessorID'])
             except (ValueError, exceptions.ConsulateException):
                 pass


### PR DESCRIPTION
Hello, 

I saw not too long ago that your consul client was missing the new Consul's ACL API. So I went ahead and wrote out the update mostly for work. 

Anyway, here's a patch for adding the updated Consul ACL for roles, policies, and tokens. I haven't gone ahead and added the auth portion of the new Consul's ACL yet, but believe the patch is in well enough shape to warrant a PR. I have left the patch unsquashed for easier review. Once you believe the PR is deemed ready, I'll go ahead rebase and squash the changes. 