### PR TITLE
Fix json.loads call to support Python 3.9

### DIFF
--- a/consulate/api/base.py
+++ b/consulate/api/base.py
@@ -165,7 +165,7 @@ class Response(object):
                         body = body.decode('utf-8')
                     except UnicodeDecodeError:
                         pass
-                value = json.loads(body, encoding='utf-8')
+                value = json.loads(body)
             except (TypeError, ValueError):
                 return body
             if value is None:


### PR DESCRIPTION
`encoding` keyword argument is ignored by `json.loads` since Python 3.1 and breaks **consulate** under Python 3.9

See https://docs.python.org/3.8/library/json.html#json.loads:

> _Deprecated since version 3.1, will be removed in version 3.9:_ _encoding_ keyword argument.