### PR TITLE
Cli interface not properly using scheme and api-port arguments

### DIFF
--- a/consulate/cli.py
+++ b/consulate/cli.py
@@ -620,8 +620,14 @@ def main():
         if args.api_host:
             api_host = args.api_host
 
-    consul = consulate.Consul(api_host, port, args.dc,
-                              args.token, args.api_scheme, adapter)
+    consul = consulate.Consul(
+        host=api_host,
+        port=port,
+        datacenter=args.dc,
+        token=args.token,
+        scheme=args.api_scheme,
+        adapter=adapter,
+    )
 
     if args.command == 'acl':
         ACL_ACTIONS[args.action](consul, args)

--- a/consulate/models/base.py
+++ b/consulate/models/base.py
@@ -6,7 +6,7 @@ Base Model
 import collections
 
 
-class Model(collections.Iterable):
+class Model(collections.abc.Iterable):
     """A model contains an __attribute__ map that defines the name,
     its type for type validation, an optional validation method, a method
     used to

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 import setuptools
 
 setuptools.setup(
-    name='abaez.consulate',
-    version='1.1.0',
+    name='consulate',
+    version='1.1.1',
     description='A Client library and command line application for the Consul',
     maintainer='Gavin M. Roy',
     maintainer_email='gavinr@aweber.com',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='consulate',
-    version='1.1.1',
+    version='1.1.2',
     description='A Client library and command line application for the Consul',
     maintainer='Gavin M. Roy',
     maintainer_email='gavinr@aweber.com',


### PR DESCRIPTION
Instanciation of Consul instance in cli.py file uses positional arguments that do not match with the __init__ declaration of the class, resulting in host parameter being used for addr, port for host and scheme for token. 

Using keyword arguments instead solves the issue and makes it more robust to function definition changes down the line.