### PR TITLE
Hotfix: Fix collections.Iterable import, deprecated per Python 3.10

### DIFF
--- a/consulate/models/base.py
+++ b/consulate/models/base.py
@@ -3,10 +3,13 @@
 Base Model
 
 """
-import collections
+try:
+    from collections import Iterable  # noqa
+except ImportError:
+    from collections.abc import Iterable  # noqa
 
 
-class Model(collections.Iterable):
+class Model(Iterable):
     """A model contains an __attribute__ map that defines the name,
     its type for type validation, an optional validation method, a method
     used to


### PR DESCRIPTION
`collections.Iterable` has been deprecated as of Python 3.10 - see Deprecation notice in https://docs.python.org/3/whatsnew/3.10.html#removed

This change makes the collections.Iterable import forward-compatible with Python>=3.10 :) 